### PR TITLE
XeliAI ecosystem nav shell, plus pricing overflow fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# Environment variables read by this app (see nuxt.config.ts, runtimeConfig.public).
+#
+# IMPORTANT: amplify.yml deploys .output/public, a STATIC build with no
+# Nitro server. That means every NUXT_PUBLIC_* value below is baked into
+# the JS bundle at BUILD time and can never be changed at runtime by
+# setting an environment variable on the running server. Each Amplify
+# branch (production, staging, preview, ...) must have its own copy of
+# these variables set in its own build environment before it builds, or
+# the branch's bundle silently inherits whatever default is hardcoded in
+# nuxt.config.ts (typically the production URL), sending that branch's
+# visitors to production services.
+#
+# Copy this file to .env for local development and fill in real values.
+# Never commit .env, and never put real secrets in this file.
+
+# Laravel backend API base URL.
+NUXT_PUBLIC_API_BASE_URL=http://localhost:8000
+
+# Public site URL (used for canonical links, SEO, etc).
+NUXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Laravel Reverb (websockets) connection settings.
+NUXT_PUBLIC_REVERB_APP_KEY=changeme
+NUXT_PUBLIC_REVERB_HOST=localhost
+NUXT_PUBLIC_REVERB_PORT=8080
+NUXT_PUBLIC_REVERB_SCHEME=http
+
+# Sibling XeliAI product URLs (ecosystem nav: Products menu, Log in menu,
+# mobile drawer, footer, landing-page ecosystem strip). Point these at
+# staging/dev URLs on non-production branches -- see the build-time
+# warning above.
+NUXT_PUBLIC_TRIVIA_URL=https://trivia.xeliai.com
+NUXT_PUBLIC_LABS_URL=https://labs.xeliai.com
+NUXT_PUBLIC_BLOG_URL=https://blog.xeliai.com

--- a/app/components/homepage/EcoLink.vue
+++ b/app/components/homepage/EcoLink.vue
@@ -4,11 +4,26 @@
   item: the desktop dropdown, the mobile drawer, and the footer. Keeping
   the external-vs-internal branching (and the security-relevant
   rel="noopener noreferrer") in one place means it can't drift between
-  those three call sites.
+  those call sites.
+
+  It is also the single place that owns the external-link affordance: a
+  small currentColor glyph for sighted users and visually-hidden text for
+  assistive tech, so every consumer gets both for free instead of each
+  one having to remember to add them.
+
+  A caller with its own designed "external" treatment (the ecosystem
+  strip's large corner arrow) can opt out of the glyph with
+  :show-external-icon="false" to avoid rendering two arrows on one link.
+  The hidden text stays either way: it is the accessibility contract, not
+  a decoration, so screen-reader users still get the context-switch
+  warning even when the visual glyph is suppressed.
 -->
 <script setup>
+import { ArrowUpRight } from 'lucide-vue-next'
+
 defineProps({
   item: { type: Object, required: true },
+  showExternalIcon: { type: Boolean, default: true },
 })
 </script>
 
@@ -20,6 +35,12 @@ defineProps({
     rel="noopener noreferrer"
   >
     <slot />
+    <ArrowUpRight
+      v-if="showExternalIcon"
+      class="inline-block w-3 h-3 ml-1 align-text-top opacity-70"
+      aria-hidden="true"
+    />
+    <span class="sr-only">(opens in a new tab)</span>
   </a>
   <NuxtLink v-else :to="item.to">
     <slot />

--- a/app/components/homepage/EcoLink.vue
+++ b/app/components/homepage/EcoLink.vue
@@ -1,0 +1,27 @@
+<!-- components/homepage/EcoLink.vue -->
+<!--
+  Single presentational link used everywhere the ecosystem nav renders an
+  item: the desktop dropdown, the mobile drawer, and the footer. Keeping
+  the external-vs-internal branching (and the security-relevant
+  rel="noopener noreferrer") in one place means it can't drift between
+  those three call sites.
+-->
+<script setup>
+defineProps({
+  item: { type: Object, required: true },
+})
+</script>
+
+<template>
+  <a
+    v-if="item.external"
+    :href="item.to"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <slot />
+  </a>
+  <NuxtLink v-else :to="item.to">
+    <slot />
+  </NuxtLink>
+</template>

--- a/app/components/homepage/EcosystemStrip.vue
+++ b/app/components/homepage/EcosystemStrip.vue
@@ -1,0 +1,46 @@
+<!-- components/homepage/EcosystemStrip.vue -->
+<script setup>
+import { ArrowUpRight } from 'lucide-vue-next'
+import { useEcosystem } from '~/composables/useEcosystem'
+
+const { products } = useEcosystem()
+
+// The sibling apps only. XeliAI is the site you are already on.
+const siblings = products.filter(p => p.external)
+</script>
+
+<template>
+  <section class="py-20 bg-white dark:bg-slate-900 transition-colors duration-300">
+    <div class="max-w-7xl mx-auto px-6 lg:px-8">
+      <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white">
+        More from XeliAI
+      </h2>
+      <p class="mt-2 text-gray-500 dark:text-gray-400 text-lg">
+        One family of products. Pick the one you need.
+      </p>
+
+      <div class="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <a
+          v-for="product in siblings"
+          :key="product.id"
+          data-ecosystem-card
+          :href="product.href"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-6 rounded-2xl border border-gray-200 dark:border-slate-800 bg-gray-50 dark:bg-slate-950 hover:border-purple-400 dark:hover:border-purple-500 hover:-translate-y-1 transition-all duration-300"
+        >
+          <div class="flex items-start justify-between gap-3">
+            <h3 class="text-lg font-bold text-gray-900 dark:text-white">{{ product.name }}</h3>
+            <ArrowUpRight
+              class="w-5 h-5 text-gray-400 group-hover:text-purple-500 transition-colors"
+              aria-hidden="true"
+            />
+          </div>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+            {{ product.tagline }}
+          </p>
+        </a>
+      </div>
+    </div>
+  </section>
+</template>

--- a/app/components/homepage/EcosystemStrip.vue
+++ b/app/components/homepage/EcosystemStrip.vue
@@ -2,6 +2,7 @@
 <script setup>
 import { ArrowUpRight } from 'lucide-vue-next'
 import { useEcosystem } from '~/composables/useEcosystem'
+import EcoLink from '~/components/homepage/EcoLink.vue'
 
 const { products } = useEcosystem()
 
@@ -20,13 +21,21 @@ const siblings = products.filter(p => p.external)
       </p>
 
       <div class="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        <a
+        <!--
+          show-external-icon is off here because this card already has its
+          own designed external-link affordance: the large ArrowUpRight in
+          the top-right corner below, with the group-hover treatment. Without
+          the opt-out, EcoLink would add a second, smaller arrow trailing the
+          tagline, which reads as a stray mark rather than a link affordance.
+          The visually-hidden "opens in a new tab" text still renders either
+          way, so screen readers get the same context-switch warning.
+        -->
+        <EcoLink
           v-for="product in siblings"
           :key="product.id"
           data-ecosystem-card
-          :href="product.href"
-          target="_blank"
-          rel="noopener noreferrer"
+          :item="{ label: product.name, to: product.href, external: product.external }"
+          :show-external-icon="false"
           class="group block p-6 rounded-2xl border border-gray-200 dark:border-slate-800 bg-gray-50 dark:bg-slate-950 hover:border-purple-400 dark:hover:border-purple-500 hover:-translate-y-1 transition-all duration-300"
         >
           <div class="flex items-start justify-between gap-3">
@@ -39,7 +48,7 @@ const siblings = products.filter(p => p.external)
           <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
             {{ product.tagline }}
           </p>
-        </a>
+        </EcoLink>
       </div>
     </div>
   </section>

--- a/app/components/homepage/Footer.vue
+++ b/app/components/homepage/Footer.vue
@@ -43,22 +43,6 @@
                   :class="{ 'nav-link--external': item.external }"
                 >
                   {{ item.label }}
-                  <svg
-                    v-if="item.external"
-                    class="ext-icon"
-                    viewBox="0 0 12 12"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    aria-hidden="true"
-                  >
-                    <path
-                      d="M2.5 9.5L9.5 2.5M9.5 2.5H5M9.5 2.5V7"
-                      stroke="currentColor"
-                      stroke-width="1.2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
                 </EcoLink>
               </nav>
             </div>
@@ -230,15 +214,6 @@ const columns = [
   display: inline-flex;
   align-items: center;
   gap: 5px;
-}
-.ext-icon {
-  width: 10px;
-  height: 10px;
-  opacity: 0.5;
-  flex-shrink: 0;
-}
-.nav-link--external:hover .ext-icon {
-  opacity: 1;
 }
 
 /* Legal bar */

--- a/app/components/homepage/Footer.vue
+++ b/app/components/homepage/Footer.vue
@@ -30,79 +30,38 @@
             </div>
           </div>
 
-      <!-- 2: Company links -->
-      <div class="space-y-5">
-        <h3 class=" text-white text-xl font-bold">Product</h3>
-        <nav class="flex flex-col space-y-2 text-sm">
-          <NuxtLink to="/features" class="text-[#9CA3AF] hover:text-gray-200">Features</NuxtLink>
-          <NuxtLink to="/pricing" class="text-[#9CA3AF] hover:text-gray-200">Pricing</NuxtLink>
-          <NuxtLink to="/referrals" class="text-[#9CA3AF] hover:text-gray-200">Referral Program</NuxtLink>
-
-        </nav>
-      </div>
           <!-- Right: Nav Columns -->
           <div class="nav-columns">
-
-            <!-- Platform -->
-            <div class="nav-col">
-              <h3 class="nav-heading">Platform</h3>
+            <div v-for="column in columns" :key="column.heading" class="nav-col">
+              <h3 class="nav-heading">{{ column.heading }}</h3>
               <nav class="nav-links">
-                <NuxtLink to="/dashboard" class="nav-link">Dashboard</NuxtLink>
-                <NuxtLink to="/dashboard/chatbot-setup" class="nav-link">Chatbot Setup</NuxtLink>
-                <NuxtLink to="/dashboard/knowledge-base" class="nav-link">Knowledge Base</NuxtLink>
-                <NuxtLink to="/dashboard/analytics" class="nav-link">Analytics</NuxtLink>
-                <NuxtLink to="/dashboard/live-monitoring" class="nav-link">Conversations</NuxtLink>
-              </nav>
-            </div>
-
-            <!-- Company -->
-            <div class="nav-col">
-              <h3 class="nav-heading">Company</h3>
-              <nav class="nav-links">
-                <NuxtLink to="/about" class="nav-link">About Us</NuxtLink>
-                <NuxtLink to="/register" class="nav-link">Get Started</NuxtLink>
-                <NuxtLink to="/login" class="nav-link">Sign In</NuxtLink>
-                <NuxtLink to="/terms" class="nav-link">Terms</NuxtLink>
-                <NuxtLink to="/contact" class="nav-link">Contact</NuxtLink>
-              </nav>
-            </div>
-
-            <!-- Support -->
-            <div class="nav-col">
-              <h3 class="nav-heading">Support</h3>
-              <nav class="nav-links">
-                <NuxtLink to="/contact" class="nav-link">Help Center</NuxtLink>
-                <NuxtLink to="/contact" class="nav-link">Contact</NuxtLink>
-                <NuxtLink to="/privacy" class="nav-link">Privacy Policy</NuxtLink>
-                <NuxtLink to="/terms" class="nav-link">Terms of Service</NuxtLink>
-              </nav>
-            </div>
-
-            <!-- Xeliai Ecosystem -->
-            <div class="nav-col">
-              <h3 class="nav-heading">Xeliai Ecosystem</h3>
-              <nav class="nav-links">
-                <a href="https://labs.xeliai.com" target="_blank" rel="noopener noreferrer" class="nav-link nav-link--external">
-                  Xeliai Labs
-                  <svg class="ext-icon" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                    <path d="M2.5 9.5L9.5 2.5M9.5 2.5H5M9.5 2.5V7" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+                <EcoLink
+                  v-for="item in column.items"
+                  :key="item.label"
+                  :item="item"
+                  class="nav-link"
+                  :class="{ 'nav-link--external': item.external }"
+                >
+                  {{ item.label }}
+                  <svg
+                    v-if="item.external"
+                    class="ext-icon"
+                    viewBox="0 0 12 12"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M2.5 9.5L9.5 2.5M9.5 2.5H5M9.5 2.5V7"
+                      stroke="currentColor"
+                      stroke-width="1.2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
                   </svg>
-                </a>
-                <a href="https://blog.xeliai.com" target="_blank" rel="noopener noreferrer" class="nav-link nav-link--external">
-                  Xeliai Blog
-                  <svg class="ext-icon" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                    <path d="M2.5 9.5L9.5 2.5M9.5 2.5H5M9.5 2.5V7" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </a>
-                <a href="https://litesigma.com" target="_blank" rel="noopener noreferrer" class="nav-link nav-link--external">
-                  Litesigma
-                  <svg class="ext-icon" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                    <path d="M2.5 9.5L9.5 2.5M9.5 2.5H5M9.5 2.5V7" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </a>
+                </EcoLink>
               </nav>
             </div>
-
           </div>
         </div>
 
@@ -111,6 +70,21 @@
           <hr class="footer-rule" />
           <div class="legal-bar">
             <span class="copyright">© {{ new Date().getFullYear() }} XELI AI · ALL RIGHTS RESERVED</span>
+
+            <a
+              v-if="parentCompany.linkEnabled"
+              data-parent-company
+              :href="parentCompany.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="powered-by"
+            >
+              Powered by {{ parentCompany.name }}
+            </a>
+            <span v-else data-parent-company class="powered-by">
+              Powered by {{ parentCompany.name }}
+            </span>
+
             <div class="legal-links">
               <NuxtLink to="/terms" class="legal-link">Terms &amp; Conditions</NuxtLink>
               <NuxtLink to="/about" class="legal-link">About</NuxtLink>
@@ -125,6 +99,20 @@
 
 <script setup>
 import { Facebook, Instagram, Linkedin } from 'lucide-vue-next'
+import EcoLink from './EcoLink.vue'
+import { useEcosystem } from '~/composables/useEcosystem'
+
+const { products, menus, parentCompany } = useEcosystem()
+
+const columns = [
+  {
+    heading: 'Products',
+    items: products.map(p => ({ label: p.name, to: p.href, external: p.external })),
+  },
+  { heading: 'Business', items: menus.business },
+  { heading: 'Company', items: menus.company.filter(i => !['Terms', 'Privacy'].includes(i.label)) },
+  { heading: 'Legal', items: menus.company.filter(i => ['Terms', 'Privacy'].includes(i.label)) },
+]
 </script>
 
 <style scoped>
@@ -271,6 +259,15 @@ import { Facebook, Instagram, Linkedin } from 'lucide-vue-next'
 .copyright {
   font-size: 12px;
   color: #4B5563;
+}
+.powered-by {
+  font-size: 12px;
+  color: #6B7280;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+}
+a.powered-by:hover {
+  color: #9CA3AF;
 }
 .legal-links {
   display: flex;

--- a/app/components/homepage/MainNavbar.vue
+++ b/app/components/homepage/MainNavbar.vue
@@ -1,55 +1,86 @@
 <!-- components/homepage/MainNavbar.vue -->
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from "vue"
+import { ref, computed } from 'vue'
 import { navLinks } from "../../utils/data"
-import { Menu, X, ChevronDown, User, LogOut, LayoutDashboard } from 'lucide-vue-next'
+import { Menu, X, User, LogOut, LayoutDashboard } from 'lucide-vue-next'
 import { useAuthStore } from '~/stores/authStore'
+import { useEcosystem } from '~/composables/useEcosystem'
+import { useDropdown } from '~/composables/useDropdown'
 import ThemeToggle from "../ui/ThemeToggle.vue"
+import NavDropdown from './NavDropdown.vue'
+import EcoLink from './EcoLink.vue'
 
 const authStore = useAuthStore()
 const router = useRouter()
 const navOpen = ref(false)
-const profileMenuOpen = ref(false)
+
+const { products, loginProducts, menus } = useEcosystem()
 
 const isAuthenticated = computed(() => authStore.isLoggedIn)
 const user = computed(() => authStore.user)
 
-const openNav = () => navOpen.value = true
-const closeNav = () => navOpen.value = false
+// Products carry taglines; the other menus are plain link lists.
+const productItems = products.map(p => ({
+  label: p.name,
+  to: p.href,
+  external: p.external,
+  tagline: p.tagline,
+}))
 
-const toggleProfileMenu = () => profileMenuOpen.value = !profileMenuOpen.value
+// Every product you can log in to. The blog has loginHref: null, so it
+// is absent here by construction.
+const loginItems = loginProducts.map(p => ({
+  label: p.name,
+  to: p.loginHref,
+  external: p.external,
+}))
+
+// Sibling products shown under the profile menu when signed in. This
+// menu knows nothing about their sessions, only where they live.
+const siblingItems = products.filter(p => p.external).map(p => ({
+  label: p.name,
+  to: p.href,
+  external: true,
+}))
+
+const openNav = () => (navOpen.value = true)
+const closeNav = () => (navOpen.value = false)
+
+// Destructured into top-level consts on purpose. Vue's string template
+// ref (ref="name") only binds to a top-level ref, so ref="profile.triggerRef"
+// would silently never bind.
+const {
+  isOpen: profileOpen,
+  toggle: toggleProfile,
+  close: closeProfile,
+  triggerRef: profileTriggerRef,
+  panelRef: profilePanelRef,
+} = useDropdown('profile')
 
 const handleLogout = async () => {
   await authStore.logout()
-  profileMenuOpen.value = false
+  closeProfile()
   router.push('/login')
 }
 
 const goToDashboard = () => {
-  profileMenuOpen.value = false
+  closeProfile()
   router.push('/dashboard')
 }
 
-// Close profile menu when clicking outside
-const handleClickOutside = (event) => {
-  const profileMenu = document.querySelector('[data-profile-menu]')
-  if (profileMenu && !profileMenu.contains(event.target)) {
-    profileMenuOpen.value = false
-  }
-}
-
-onMounted(() => document.addEventListener('click', handleClickOutside))
-onUnmounted(() => document.removeEventListener('click', handleClickOutside))
+// Mobile accordion state.
+const openSection = ref(null)
+const toggleSection = (key) => (openSection.value = openSection.value === key ? null : key)
 </script>
 
 <template>
-   <nav 
+   <nav
      class="transition-all duration-300 h-16 md:h-20 z-[100] fixed top-0 inset-x-0
-         bg-white/90 backdrop-blur-md 
+         bg-white/90 backdrop-blur-md
          dark:bg-slate-900/95 dark:border-slate-800 border-b border-transparent
-         
+
          "
-  role="navigation" 
+  role="navigation"
   aria-label="Main navigation"
   >
     <div class="flex items-center h-full md:w-[95%] lg:w-[95%] justify-between sm:w-[80%] mx-[2rem]">
@@ -59,35 +90,35 @@ onUnmounted(() => document.removeEventListener('click', handleClickOutside))
       </NuxtLink>
 
       <!-- Desktop Nav -->
-      <div class="hidden lg:flex items-center space-x-10">
-        <NuxtLink v-for="link in navLinks" :key="link.id" :to="link.url"
-          class="text-gray-600 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 font-medium gap-2 flex transition-all duration-200 rounded-md px-2 py-1"
-          :aria-label="link.label">
-          <p>{{ link.label }}</p>
-          <p class="flex items-center" v-if="link.more">
-            <ChevronDown class="w-4 h-4 ml-1" aria-hidden="true" />
-          </p>
+      <div data-desktop-nav class="hidden lg:flex items-center space-x-6">
+        <NavDropdown id="products" label="Products" :items="productItems" />
+        <NavDropdown id="business" label="Business" :items="menus.business" />
+        <NavDropdown id="company" label="Company" :items="menus.company" />
+        <NuxtLink
+          to="/pricing"
+          class="px-2 py-1 rounded-md font-medium text-gray-600 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors duration-200"
+        >
+          Pricing
         </NuxtLink>
       </div>
 
       <!-- Buttons & Toggles -->
       <div class="flex items-center space-x-4">
-        
+
         <!-- THEME TOGGLE (Desktop) -->
         <div class="hidden lg:block">
           <ThemeToggle />
         </div>
 
         <!-- Authenticated User Menu -->
-        <div v-if="isAuthenticated" class="hidden lg:block relative" data-profile-menu>
-          <button @click.stop="toggleProfileMenu"
+        <div v-if="isAuthenticated" class="hidden lg:block relative">
+          <button @click.stop="toggleProfile" ref="profileTriggerRef"
             class="flex items-center space-x-2 px-4 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors"
-            aria-label="User menu" :aria-expanded="profileMenuOpen">
+            aria-label="User menu" :aria-expanded="profileOpen ? 'true' : 'false'">
             <div class="w-8 h-8 rounded-full bg-purple-100 flex items-center justify-center border border-purple-200">
               <User class="w-5 h-5 text-purple-600" aria-hidden="true" />
             </div>
             <span class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ user?.name || 'User' }}</span>
-            <ChevronDown class="w-4 h-4 text-gray-600 dark:text-gray-400" :class="{ 'rotate-180': profileMenuOpen }" aria-hidden="true" />
           </button>
 
           <!-- Dropdown Menu -->
@@ -95,7 +126,7 @@ onUnmounted(() => document.removeEventListener('click', handleClickOutside))
             enter-from-class="transform opacity-0 scale-95" enter-to-class="transform opacity-100 scale-100"
             leave-active-class="transition ease-in duration-75" leave-from-class="transform opacity-100 scale-100"
             leave-to-class="transform opacity-0 scale-95">
-            <div v-if="profileMenuOpen"
+            <div v-if="profileOpen" ref="profilePanelRef"
               class="absolute right-0 mt-2 w-56 rounded-lg shadow-lg bg-white dark:bg-slate-800 ring-1 ring-black ring-opacity-5 focus:outline-none z-50 border border-gray-100 dark:border-slate-700"
               role="menu" aria-orientation="vertical">
               <div class="p-2">
@@ -111,18 +142,35 @@ onUnmounted(() => document.removeEventListener('click', handleClickOutside))
                   <LogOut class="w-4 h-4 mr-3" aria-hidden="true" />
                   Logout
                 </button>
+                <div class="my-2 border-t border-gray-100 dark:border-slate-700"></div>
+                <p class="px-4 pb-1 text-xs font-semibold uppercase tracking-wide text-gray-400">
+                  More from XeliAI
+                </p>
+                <EcoLink
+                  v-for="item in siblingItems"
+                  :key="item.label"
+                  :item="item"
+                  class="w-full flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-purple-50 dark:hover:bg-slate-700 hover:text-purple-600 rounded-md transition-colors"
+                  role="menuitem"
+                >
+                  {{ item.label }}
+                </EcoLink>
               </div>
             </div>
           </Transition>
         </div>
 
-        <!-- Get Started Button -->
-        <NuxtLink v-else class="hidden lg:block" to="/get-started">
-          <button
-            class="px-8 py-3 nav_primary_btn text-white rounded-lg transition-transform hover:-translate-y-0.5 shadow-lg shadow-purple-500/20">
-            Get Started
-          </button>
-        </NuxtLink>
+        <!-- Log in menu + primary CTA -->
+        <div v-else class="hidden lg:flex items-center gap-3">
+          <NavDropdown id="login" label="Log in" :items="loginItems" align="end" />
+          <NuxtLink to="/get-started">
+            <button
+              class="px-8 py-3 nav_primary_btn text-white rounded-lg transition-transform hover:-translate-y-0.5 shadow-lg shadow-purple-500/20"
+            >
+              Get Started
+            </button>
+          </NuxtLink>
+        </div>
 
         <!-- THEME TOGGLE (Mobile) -->
         <div class="lg:hidden">
@@ -144,7 +192,7 @@ onUnmounted(() => document.removeEventListener('click', handleClickOutside))
       class="fixed top-0 left-0 h-screen w-[80%] sm:w-[60%] bg-[#9E4CFF] text-white flex flex-col z-[1050] shadow-2xl transition-transform duration-300"
       :class="navOpen ? 'translate-x-0' : '-translate-x-full'" role="dialog" aria-modal="true"
       aria-label="Mobile navigation">
-      
+
       <!-- Close Button (Absolute to stay fixed while content scrolls) -->
       <div class="absolute top-6 right-6 z-20">
         <X @click="closeNav" class="w-8 h-8 cursor-pointer hover:rotate-90 transition-transform hover:opacity-80"
@@ -154,7 +202,7 @@ onUnmounted(() => document.removeEventListener('click', handleClickOutside))
       <!-- Scrollable Content Container -->
       <!-- 'no-scrollbar' class added via style tag below -->
       <div class="flex-1 overflow-y-auto no-scrollbar flex flex-col px-10 py-20">
-        
+
         <!-- Navigation Links -->
         <!-- Reduced text size: text-lg sm:text-2xl -->
         <div class="flex flex-col space-y-6">
@@ -179,7 +227,7 @@ onUnmounted(() => document.removeEventListener('click', handleClickOutside))
               Logout
             </button>
           </div>
-          
+
           <NuxtLink v-else to="/get-started" @click="closeNav" class="block">
             <!-- White button with Purple text for high contrast -->
             <button

--- a/app/components/homepage/MainNavbar.vue
+++ b/app/components/homepage/MainNavbar.vue
@@ -2,7 +2,7 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { navLinks } from "../../utils/data"
-import { Menu, X, User, LogOut, LayoutDashboard } from 'lucide-vue-next'
+import { Menu, X, User, LogOut, LayoutDashboard, ChevronDown } from 'lucide-vue-next'
 import { useAuthStore } from '~/stores/authStore'
 import { useEcosystem } from '~/composables/useEcosystem'
 import { useDropdown } from '~/composables/useDropdown'
@@ -43,6 +43,13 @@ const siblingItems = products.filter(p => p.external).map(p => ({
   external: true,
 }))
 
+// The mobile drawer's three accordion sections.
+const drawerSections = [
+  { key: 'products', label: 'Products', items: productItems },
+  { key: 'business', label: 'Business', items: menus.business },
+  { key: 'company', label: 'Company', items: menus.company },
+]
+
 const openNav = () => (navOpen.value = true)
 const closeNav = () => (navOpen.value = false)
 
@@ -71,6 +78,31 @@ const goToDashboard = () => {
 // Mobile accordion state.
 const openSection = ref(null)
 const toggleSection = (key) => (openSection.value = openSection.value === key ? null : key)
+
+const drawerRef = ref(null)
+
+// aria-modal is a promise to keyboard users. Without a trap, focus walks
+// straight out of the drawer into the page behind it.
+const onDrawerKeydown = (event) => {
+  if (event.key === 'Escape') { closeNav(); return }
+  if (event.key !== 'Tab') return
+
+  const focusables = drawerRef.value?.querySelectorAll(
+    'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  )
+  if (!focusables?.length) return
+
+  const first = focusables[0]
+  const last = focusables[focusables.length - 1]
+
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
 </script>
 
 <template>
@@ -119,6 +151,7 @@ const toggleSection = (key) => (openSection.value = openSection.value === key ? 
               <User class="w-5 h-5 text-purple-600" aria-hidden="true" />
             </div>
             <span class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ user?.name || 'User' }}</span>
+            <ChevronDown class="w-4 h-4 text-gray-600 dark:text-gray-400" :class="{ 'rotate-180': profileOpen }" aria-hidden="true" />
           </button>
 
           <!-- Dropdown Menu -->
@@ -189,9 +222,10 @@ const toggleSection = (key) => (openSection.value = openSection.value === key ? 
 
     <!-- Mobile Nav Drawer -->
     <aside
+      ref="drawerRef"
       class="fixed top-0 left-0 h-screen w-[80%] sm:w-[60%] bg-[#9E4CFF] text-white flex flex-col z-[1050] shadow-2xl transition-transform duration-300"
       :class="navOpen ? 'translate-x-0' : '-translate-x-full'" role="dialog" aria-modal="true"
-      aria-label="Mobile navigation">
+      aria-label="Mobile navigation" @keydown="onDrawerKeydown">
 
       <!-- Close Button (Absolute to stay fixed while content scrolls) -->
       <div class="absolute top-6 right-6 z-20">
@@ -205,11 +239,46 @@ const toggleSection = (key) => (openSection.value = openSection.value === key ? 
 
         <!-- Navigation Links -->
         <!-- Reduced text size: text-lg sm:text-2xl -->
-        <div class="flex flex-col space-y-6">
-          <NuxtLink v-for="link in navLinks" :key="link.id" :to="link.url"
-            class="text-lg sm:text-2xl font-semibold border-b border-white/20 pb-2 hover:border-white transition-all w-fit"
-            @click="closeNav">
-            {{ link.label }}
+        <div class="flex flex-col space-y-2">
+          <div v-for="section in drawerSections" :key="section.key" class="border-b border-white/20 pb-2">
+            <button
+              type="button"
+              data-drawer-section
+              class="w-full flex items-center justify-between text-lg sm:text-2xl font-semibold py-2"
+              :aria-expanded="openSection === section.key ? 'true' : 'false'"
+              :aria-controls="`drawer-panel-${section.key}`"
+              @click="toggleSection(section.key)"
+            >
+              {{ section.label }}
+              <ChevronDown
+                class="w-5 h-5 transition-transform"
+                :class="{ 'rotate-180': openSection === section.key }"
+                aria-hidden="true"
+              />
+            </button>
+            <div
+              v-show="openSection === section.key"
+              :id="`drawer-panel-${section.key}`"
+              class="flex flex-col space-y-3 pb-3 pl-2"
+            >
+              <EcoLink
+                v-for="item in section.items"
+                :key="item.label"
+                :item="item"
+                class="text-base text-white/80 hover:text-white transition-colors"
+                @click="closeNav"
+              >
+                {{ item.label }}
+              </EcoLink>
+            </div>
+          </div>
+
+          <NuxtLink
+            to="/pricing"
+            class="text-lg sm:text-2xl font-semibold border-b border-white/20 py-2 hover:border-white transition-all"
+            @click="closeNav"
+          >
+            Pricing
           </NuxtLink>
         </div>
 
@@ -228,13 +297,29 @@ const toggleSection = (key) => (openSection.value = openSection.value === key ? 
             </button>
           </div>
 
-          <NuxtLink v-else to="/get-started" @click="closeNav" class="block">
-            <!-- White button with Purple text for high contrast -->
-            <button
-              class="w-full px-8 py-3 bg-white text-[#9E4CFF] font-bold text-base sm:text-lg rounded-xl shadow-lg hover:bg-gray-50 transition-colors">
-              Get Started
-            </button>
-          </NuxtLink>
+          <div v-else>
+            <div data-drawer-logins class="mb-4 space-y-2">
+              <p class="text-xs font-semibold uppercase tracking-wide text-white/60">Log in to</p>
+              <EcoLink
+                v-for="item in loginItems"
+                :key="item.label"
+                :item="item"
+                class="block text-base text-white/90 hover:text-white transition-colors"
+                @click="closeNav"
+              >
+                {{ item.label }}
+              </EcoLink>
+            </div>
+
+            <NuxtLink to="/get-started" class="block" @click="closeNav">
+              <!-- White button with Purple text for high contrast -->
+              <button
+                class="w-full px-8 py-3 bg-white text-[#9E4CFF] font-bold text-base sm:text-lg rounded-xl shadow-lg hover:bg-gray-50 transition-colors"
+              >
+                Get Started
+              </button>
+            </NuxtLink>
+          </div>
         </div>
       </div>
     </aside>

--- a/app/components/homepage/MainNavbar.vue
+++ b/app/components/homepage/MainNavbar.vue
@@ -1,7 +1,6 @@
 <!-- components/homepage/MainNavbar.vue -->
 <script setup>
 import { ref, computed } from 'vue'
-import { navLinks } from "../../utils/data"
 import { Menu, X, User, LogOut, LayoutDashboard, ChevronDown } from 'lucide-vue-next'
 import { useAuthStore } from '~/stores/authStore'
 import { useEcosystem } from '~/composables/useEcosystem'

--- a/app/components/homepage/MainNavbar.vue
+++ b/app/components/homepage/MainNavbar.vue
@@ -83,7 +83,13 @@ const drawerRef = ref(null)
 
 // aria-modal is a promise to keyboard users. Without a trap, focus walks
 // straight out of the drawer into the page behind it.
+//
+// The drawer is hidden by a CSS transform, not display/visibility/inert,
+// so its contents stay in the tab order even while closed. Without this
+// guard the wrap logic below fires on a closed, invisible drawer and
+// traps focus inside it before the user ever opens it.
 const onDrawerKeydown = (event) => {
+  if (!navOpen.value) return
   if (event.key === 'Escape') { closeNav(); return }
   if (event.key !== 'Tab') return
 

--- a/app/components/homepage/MainNavbar.vue
+++ b/app/components/homepage/MainNavbar.vue
@@ -83,10 +83,14 @@ const drawerRef = ref(null)
 // aria-modal is a promise to keyboard users. Without a trap, focus walks
 // straight out of the drawer into the page behind it.
 //
-// The drawer is hidden by a CSS transform, not display/visibility/inert,
-// so its contents stay in the tab order even while closed. Without this
-// guard the wrap logic below fires on a closed, invisible drawer and
-// traps focus inside it before the user ever opens it.
+// The drawer is hidden by a CSS transform, so its contents are still
+// visually removed but the :inert binding on the <aside> below now
+// honours the aria-modal promise: while closed, the browser excludes the
+// drawer from the tab order and the accessibility tree on its own. This
+// guard is kept as a redundant safety net (older engines without inert
+// support, or any future change that drops the binding) so the wrap
+// logic below never fires on a closed, invisible drawer and traps focus
+// inside it before the user ever opens it.
 const onDrawerKeydown = (event) => {
   if (!navOpen.value) return
   if (event.key === 'Escape') { closeNav(); return }
@@ -151,7 +155,7 @@ const onDrawerKeydown = (event) => {
         <div v-if="isAuthenticated" class="hidden lg:block relative">
           <button @click.stop="toggleProfile" ref="profileTriggerRef"
             class="flex items-center space-x-2 px-4 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors"
-            aria-label="User menu" :aria-expanded="profileOpen ? 'true' : 'false'">
+            aria-label="User menu" aria-haspopup="menu" :aria-expanded="profileOpen ? 'true' : 'false'">
             <div class="w-8 h-8 rounded-full bg-purple-100 flex items-center justify-center border border-purple-200">
               <User class="w-5 h-5 text-purple-600" aria-hidden="true" />
             </div>
@@ -190,6 +194,7 @@ const onDrawerKeydown = (event) => {
                   :item="item"
                   class="w-full flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-purple-50 dark:hover:bg-slate-700 hover:text-purple-600 rounded-md transition-colors"
                   role="menuitem"
+                  @click="closeProfile"
                 >
                   {{ item.label }}
                 </EcoLink>
@@ -228,6 +233,7 @@ const onDrawerKeydown = (event) => {
     <!-- Mobile Nav Drawer -->
     <aside
       ref="drawerRef"
+      :inert="!navOpen"
       class="fixed top-0 left-0 h-screen w-[80%] sm:w-[60%] bg-[#9E4CFF] text-white flex flex-col z-[1050] shadow-2xl transition-transform duration-300"
       :class="navOpen ? 'translate-x-0' : '-translate-x-full'" role="dialog" aria-modal="true"
       aria-label="Mobile navigation" @keydown="onDrawerKeydown">

--- a/app/components/homepage/NavDropdown.vue
+++ b/app/components/homepage/NavDropdown.vue
@@ -1,5 +1,6 @@
 <!-- components/homepage/NavDropdown.vue -->
 <script setup>
+import { nextTick, watch } from 'vue'
 import { ChevronDown } from 'lucide-vue-next'
 import { useDropdown } from '~/composables/useDropdown'
 import EcoLink from '~/components/homepage/EcoLink.vue'
@@ -12,6 +13,18 @@ const props = defineProps({
 })
 
 const { isOpen, toggle, close, closeAndRefocus, triggerRef, panelRef } = useDropdown(props.id)
+
+// FIX 2: arrow-key roving focus only works once focus is actually inside
+// the panel. The trigger and the panel are siblings, so clicking the
+// trigger leaves focus on the trigger and keydown never reaches
+// onPanelKeydown below. Move focus to the first menu item once the panel
+// has rendered (it is behind v-if inside a Transition, so wait a tick).
+watch(isOpen, async (open) => {
+  if (!open) return
+  await nextTick()
+  const first = panelRef.value?.querySelector('[role="menuitem"]')
+  first?.focus()
+})
 
 // Roving focus through the menu with the arrow keys.
 const onPanelKeydown = (event) => {
@@ -32,7 +45,30 @@ const onPanelKeydown = (event) => {
     event.preventDefault()
     focusables[focusables.length - 1].focus()
   } else if (event.key === 'Tab') {
-    close()
+    // FIX 1: closing on every Tab used to strand focus. Tab between two
+    // items inside the menu is native browser behaviour (these are real
+    // anchors, not a roving-tabindex set) and must be left alone, or the
+    // item that focus lands on gets ripped out from under it the instant
+    // we close. Only the boundary case needs handling: Tab off the last
+    // item (or Shift+Tab off the first) is about to carry focus out of
+    // the panel entirely, so it is safe to close there.
+    const leavingForward = !event.shiftKey && current === focusables.length - 1
+    const leavingBackward = event.shiftKey && current === 0
+    if (leavingForward || leavingBackward) {
+      // Do not close synchronously: the browser has not yet performed
+      // its default Tab focus-move (that happens right after this
+      // handler returns, still before the next animation frame). If we
+      // close now, we delete the currently-focused element before the
+      // browser gets a chance to move focus off it, so it falls back to
+      // <body> and sequential navigation restarts from the top of the
+      // page -- the exact bug this fix removes. Deferring to the next
+      // frame lets the native Tab motion land on whatever comes after
+      // this menu first; only then do we tear the panel down, and focus
+      // is already safely outside it.
+      requestAnimationFrame(() => close())
+    }
+    // Any other Tab moves between items and is left entirely to the
+    // browser's native focus order; the menu stays open.
   }
 }
 </script>

--- a/app/components/homepage/NavDropdown.vue
+++ b/app/components/homepage/NavDropdown.vue
@@ -1,0 +1,91 @@
+<!-- components/homepage/NavDropdown.vue -->
+<script setup>
+import { ChevronDown } from 'lucide-vue-next'
+import { useDropdown } from '~/composables/useDropdown'
+import EcoLink from '~/components/homepage/EcoLink.vue'
+
+const props = defineProps({
+  id: { type: String, required: true },
+  label: { type: String, required: true },
+  items: { type: Array, required: true },
+  align: { type: String, default: 'start' },
+})
+
+const { isOpen, toggle, close, closeAndRefocus, triggerRef, panelRef } = useDropdown(props.id)
+
+// Roving focus through the menu with the arrow keys.
+const onPanelKeydown = (event) => {
+  const focusables = Array.from(panelRef.value?.querySelectorAll('[role="menuitem"]') ?? [])
+  if (!focusables.length) return
+  const current = focusables.indexOf(document.activeElement)
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    focusables[(current + 1) % focusables.length].focus()
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    focusables[(current - 1 + focusables.length) % focusables.length].focus()
+  } else if (event.key === 'Home') {
+    event.preventDefault()
+    focusables[0].focus()
+  } else if (event.key === 'End') {
+    event.preventDefault()
+    focusables[focusables.length - 1].focus()
+  } else if (event.key === 'Tab') {
+    close()
+  }
+}
+</script>
+
+<template>
+  <div class="relative">
+    <button
+      ref="triggerRef"
+      type="button"
+      class="flex items-center gap-1 px-2 py-1 rounded-md font-medium text-gray-600 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors duration-200"
+      aria-haspopup="menu"
+      :aria-expanded="isOpen ? 'true' : 'false'"
+      @click.stop="toggle"
+    >
+      {{ label }}
+      <ChevronDown
+        class="w-4 h-4 transition-transform duration-200"
+        :class="{ 'rotate-180': isOpen }"
+        aria-hidden="true"
+      />
+    </button>
+
+    <Transition
+      enter-active-class="transition ease-out duration-100"
+      enter-from-class="transform opacity-0 scale-95"
+      enter-to-class="transform opacity-100 scale-100"
+      leave-active-class="transition ease-in duration-75"
+      leave-from-class="transform opacity-100 scale-100"
+      leave-to-class="transform opacity-0 scale-95"
+    >
+      <div
+        v-if="isOpen"
+        ref="panelRef"
+        role="menu"
+        :aria-label="label"
+        class="absolute mt-2 w-72 rounded-xl shadow-lg bg-white dark:bg-slate-800 ring-1 ring-black/5 border border-gray-100 dark:border-slate-700 p-2 z-50"
+        :class="align === 'end' ? 'right-0' : 'left-0'"
+        @keydown="onPanelKeydown"
+      >
+        <EcoLink
+          v-for="item in items"
+          :key="item.label"
+          :item="item"
+          role="menuitem"
+          class="block px-3 py-2 rounded-lg text-sm text-gray-700 dark:text-gray-200 hover:bg-purple-50 dark:hover:bg-slate-700 hover:text-purple-600 transition-colors"
+          @click="closeAndRefocus"
+        >
+          <span class="font-medium">{{ item.label }}</span>
+          <span v-if="item.tagline" class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {{ item.tagline }}
+          </span>
+        </EcoLink>
+      </div>
+    </Transition>
+  </div>
+</template>

--- a/app/components/homepage/PricingCard.vue
+++ b/app/components/homepage/PricingCard.vue
@@ -37,8 +37,13 @@
         </p>  
       </header>  
 
-      <div class="flex items-baseline gap-1 mb-8">
-        <div class="text-4xl md:text-5xl font-extrabold leading-none tracking-tight">
+      <!-- flex-wrap + min-w-0 are load-bearing: the price is a preformatted
+           string from the API and can be far wider than a USD literal
+           (compare "$99" with "NGN 450,000.00"). Without them the suffix is
+           pushed outside the card, where the featured variant lets it bleed
+           (it needs overflow-visible for the ribbon) and the others clip it. -->
+      <div class="flex flex-wrap items-baseline gap-x-1 mb-8 min-w-0">
+        <div data-price :class="priceSizeClass" class="font-extrabold leading-none tracking-tight tabular-nums min-w-0 max-w-full break-words">
           <span v-if="priceText" class="inline-block">{{ priceText }}</span>
           <!-- Skeleton bar: shown while the parent has no priceText yet
                (i.e. /api/plans hasn't returned). Prevents the USD-literal
@@ -95,7 +100,9 @@
 </template>
 
 <script setup>
-defineProps({
+import { computed } from 'vue'
+
+const props = defineProps({
   planId: { type: String, required: true },
   title: { type: String, required: true },
   subtitle: { type: String, default: '' },
@@ -111,4 +118,18 @@ defineProps({
 })
 
 defineEmits(['select-plan'])
+
+// The price is a preformatted string from the API, so its width is not
+// something this component controls: "Free" is 4 characters, "NGN
+// 450,000.00" is 11, and a larger currency could be longer still. A card
+// column is about 314px of content at the md breakpoint, which a fixed
+// text-5xl cannot hold past roughly 7 characters. Step the size down by
+// length so long values stay inside the card, and let flex-wrap catch
+// anything longer than these tiers anticipate.
+const priceSizeClass = computed(() => {
+  const length = (props.priceText ?? '').length
+  if (length <= 6) return 'text-4xl md:text-5xl'
+  if (length <= 12) return 'text-3xl md:text-4xl'
+  return 'text-2xl md:text-3xl'
+})
 </script>

--- a/app/components/homepage/ProductSuite.vue
+++ b/app/components/homepage/ProductSuite.vue
@@ -10,11 +10,11 @@
       <div class="flex flex-col md:flex-row md:items-center justify-between mb-12 gap-6">
         <div>
 
-          <h2 
+          <h2
             class="text-4xl sm:text-5xl font-extrabold tracking-tight bg-clip-text text-transparent pb-2"
             style="background-image: linear-gradient(90deg, #9E4CFF, #2563EB);"
           >
-            Product Suite
+            What XeliAI does
           </h2>
 
           <p class="mt-2 text-gray-500 dark:text-gray-400 max-w-xl text-lg transition-colors">
@@ -23,11 +23,6 @@
         </div>
 
 
-        <div class="flex flex-wrap gap-2 items-center bg-white dark:bg-slate-900 p-1.5 rounded-xl border border-gray-200 dark:border-slate-800 shadow-sm transition-colors">
-          <button class="px-4 py-1.5 rounded-lg text-sm font-medium bg-gray-100 text-gray-900 shadow-sm dark:bg-slate-800 dark:text-white transition-colors">All</button>
-          <button class="px-4 py-1.5 rounded-lg text-sm font-medium text-gray-500 hover:text-gray-900 hover:bg-gray-50 transition-colors dark:text-gray-400 dark:hover:text-white dark:hover:bg-slate-800">Support</button>
-          <button class="px-4 py-1.5 rounded-lg text-sm font-medium text-gray-500 hover:text-gray-900 hover:bg-gray-50 transition-colors dark:text-gray-400 dark:hover:text-white dark:hover:bg-slate-800">Automation</button>
-        </div>
       </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">

--- a/app/composables/useDropdown.js
+++ b/app/composables/useDropdown.js
@@ -1,0 +1,58 @@
+// ~/composables/useDropdown.js
+// Shared open/close behaviour for every nav dropdown.
+// Open state lives in useState, not a module-level ref, because a
+// module-level ref leaks state between requests during SSR.
+import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
+
+export function useDropdown(id) {
+  const openId = useState('nav:openDropdown', () => null)
+  const triggerRef = ref(null)
+  const panelRef = ref(null)
+
+  const isOpen = computed(() => openId.value === id)
+
+  const open = () => { openId.value = id }
+  const close = () => { if (openId.value === id) openId.value = null }
+  const toggle = () => (isOpen.value ? close() : open())
+
+  // Used by Escape and by selecting an item: focus must go back to the
+  // trigger, or keyboard users are dumped at the top of the document.
+  const closeAndRefocus = () => {
+    const el = triggerRef.value?.$el ?? triggerRef.value
+    close()
+    el?.focus?.()
+  }
+
+  const onDocumentClick = (event) => {
+    if (!isOpen.value) return
+    const trigger = triggerRef.value?.$el ?? triggerRef.value
+    const panel = panelRef.value?.$el ?? panelRef.value
+    if (trigger?.contains(event.target)) return
+    if (panel?.contains(event.target)) return
+    close()
+  }
+
+  const onKeydown = (event) => {
+    if (!isOpen.value) return
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeAndRefocus()
+    }
+  }
+
+  onMounted(() => {
+    document.addEventListener('click', onDocumentClick)
+    document.addEventListener('keydown', onKeydown)
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('click', onDocumentClick)
+    document.removeEventListener('keydown', onKeydown)
+  })
+
+  // Navigating away must not leave a menu hanging open.
+  const router = useRouter()
+  watch(() => router.currentRoute.value.fullPath, () => close())
+
+  return { isOpen, open, close, toggle, closeAndRefocus, triggerRef, panelRef }
+}

--- a/app/composables/useEcosystem.js
+++ b/app/composables/useEcosystem.js
@@ -1,0 +1,20 @@
+// ~/composables/useEcosystem.js
+import { buildProducts, menus, parentCompany } from '~/utils/ecosystem'
+
+export function useEcosystem() {
+  const config = useRuntimeConfig()
+
+  const products = buildProducts({
+    triviaUrl: config.public.triviaUrl,
+    labsUrl: config.public.labsUrl,
+    blogUrl: config.public.blogUrl,
+  })
+
+  return {
+    products,
+    // Products you can actually log in to. The blog has loginHref: null.
+    loginProducts: products.filter(p => p.loginHref !== null),
+    menus,
+    parentCompany,
+  }
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,7 +2,8 @@
     <div class="overflow-hidden">
       <Hero />
       <ProductSuite />
-      <Features />    
+      <EcosystemStrip />
+      <Features />
       <TestimonialCarousel />
       <CtaBanner />
       <GradualBlur
@@ -19,6 +20,7 @@
 <script setup>
 import  Hero from '../components/homepage/Hero.vue'
 import ProductSuite from '../components/homepage/ProductSuite.vue'
+import EcosystemStrip from '../components/homepage/EcosystemStrip.vue'
 import Features from '../components/homepage/Features.vue'
 import TestimonialCarousel from '~/components/homepage/TestimonialCarousel.vue'
 import CtaBanner from '../components/homepage/CtaBanner.vue'

--- a/app/utils/data.js
+++ b/app/utils/data.js
@@ -1,14 +1,3 @@
-// ~/utils/data.js (or wherever you export navLinks)
-export const navLinks = [
-  { id: 1, url: '/',           more: '',                  label: 'Home' },
-  { id: 2, url: '/about',   more:'',   label: 'About' },
-  { id: 3, url: '/products',more: '',                  label: 'Products' },
-  { id: 4, url: '/pricing',    more: '',                  label: 'Pricing' },
-  { id: 5, url: '/referrals', more: '',                  label: 'Referral Program' },
-  { id: 6, url: 'https://blog.xeliai.com',       more: '',                  label: 'Blog' },
-  { id: 7, url: '/contact',    more: '',                  label: 'Contact' },
-]
-
 // ~/data/homepage/content.js
 export const features = [
   {

--- a/app/utils/ecosystem.js
+++ b/app/utils/ecosystem.js
@@ -41,6 +41,14 @@ export function buildProducts({ triviaUrl, labsUrl, blogUrl }) {
   ]
 }
 
+// Declared before `menus` so the Company menu can point at the same URL
+// rather than repeating it. One string, one place to change it.
+export const parentCompany = {
+  name: 'LiteSigma Tech',
+  url: 'https://www.litesigma.com.ng/',
+  linkEnabled: true,
+}
+
 export const menus = {
   business: [
     { label: 'Pricing', to: '/pricing' },
@@ -51,14 +59,10 @@ export const menus = {
   company: [
     { label: 'About', to: '/about' },
     { label: 'Contact', to: '/contact' },
+    // Label and URL both come from parentCompany so the menu entry and the
+    // footer credit can never disagree about the company's name.
+    { label: parentCompany.name, to: parentCompany.url, external: true },
     { label: 'Terms', to: '/terms' },
     { label: 'Privacy', to: '/privacy' },
   ],
-}
-
-export const parentCompany = {
-  name: 'LiteSigma',
-  url: 'https://litesigma.com',
-  // litesigma.com does not resolve as of 2026-08-12. Flip to true when it does.
-  linkEnabled: false,
 }

--- a/app/utils/ecosystem.js
+++ b/app/utils/ecosystem.js
@@ -1,0 +1,64 @@
+// ~/utils/ecosystem.js
+// Single source of truth for the XeliAI product family.
+// The navbar, mobile drawer, login menu and footer all read from here.
+// Sibling URLs are injected so this file stays pure and testable.
+
+export function buildProducts({ triviaUrl, labsUrl, blogUrl }) {
+  return [
+    {
+      id: 'xeliai',
+      name: 'XeliAI',
+      tagline: 'AI chatbot trained on your business data',
+      href: '/products',
+      loginHref: '/login',
+      external: false,
+    },
+    {
+      id: 'trivia',
+      name: 'XeliAI Trivia',
+      tagline: 'Turn any study material into adaptive practice',
+      href: triviaUrl,
+      loginHref: `${triviaUrl}/auth/login`,
+      external: true,
+    },
+    {
+      id: 'labs',
+      name: 'XeliAI Labs',
+      tagline: 'Courses, mentorship and talent',
+      // Labs has no working auth yet, so this points at its home page.
+      loginHref: labsUrl,
+      href: labsUrl,
+      external: true,
+    },
+    {
+      id: 'blog',
+      name: 'XeliAI Blog',
+      tagline: 'Product news and writing',
+      href: blogUrl,
+      loginHref: null, // no login: excluded from the login menu
+      external: true,
+    },
+  ]
+}
+
+export const menus = {
+  business: [
+    { label: 'Pricing', to: '/pricing' },
+    { label: 'Referral Program', to: '/referrals' },
+    { label: 'Talk to sales', to: '/contact' },
+    { label: 'Get started', to: '/get-started' },
+  ],
+  company: [
+    { label: 'About', to: '/about' },
+    { label: 'Contact', to: '/contact' },
+    { label: 'Terms', to: '/terms' },
+    { label: 'Privacy', to: '/privacy' },
+  ],
+}
+
+export const parentCompany = {
+  name: 'LiteSigma',
+  url: 'https://litesigma.com',
+  // litesigma.com does not resolve as of 2026-08-12. Flip to true when it does.
+  linkEnabled: false,
+}

--- a/docs/superpowers/plans/2026-08-12-ecosystem-nav-shell.md
+++ b/docs/superpowers/plans/2026-08-12-ecosystem-nav-shell.md
@@ -1,0 +1,1607 @@
+# XeliAI Ecosystem Nav Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the XeliAI landing page into the hub for the product family, with a Products menu, Business and Company menus, a Log in dropdown that routes to each product's own login, and a "Powered by LiteSigma" footer credit.
+
+**Architecture:** One registry (`app/utils/ecosystem.js`) is the single source of truth for products and menus. A `useEcosystem()` composable resolves product URLs from `runtimeConfig.public` at call time. A `useDropdown()` composable holds all open/close, keyboard and click-outside logic, shared by all four dropdowns. Nothing hardcodes a product name or URL outside the registry.
+
+**Tech Stack:** Nuxt 4, Vue 3, Pinia, Tailwind 4, vitest + `@nuxt/test-utils`.
+
+**Design doc:** `docs/superpowers/specs/2026-08-12-ecosystem-nav-shell-design.md`
+
+---
+
+## Global Constraints
+
+These apply to every task. Read them once, obey them throughout.
+
+- **Branch:** work on `dev`. Commit after every task. Do not push without asking.
+- **No em dashes in user-facing copy.** No `—` in any tagline, label, heading, button or footer string. Use a comma or a full stop. This applies to strings a visitor reads, not to code comments.
+- **No new npm dependencies.** Everything needed is installed. `@pinia/testing` is *not* installed and must not be added; it is not needed.
+- **Test command is `npx vitest run`.** Not `npm run test` — that runs bare `vitest`, which watches in a TTY and will hang an agent.
+- **All test files live in `test/nuxt/`** and must end in `.spec.ts` or `.test.ts`. The vitest config has exactly one project, `nuxt`, whose include glob is `test/nuxt/*.{test,spec}.ts`. A test placed anywhere else silently does not run.
+- **Any test that mounts `MainNavbar` MUST stub `ThemeToggle`.** `ThemeToggle.vue:19` reads `colorMode.value`, and `@nuxtjs/color-mode` fails to initialise in the test environment, so `colorMode` is `undefined` and the render throws. Use `global: { stubs: { ThemeToggle: true } }`. This is verified, not theoretical.
+- **Expect this stderr line in every test run — it is harmless:**
+  `[nuxt] error caught during app initialization TypeError: Cannot read properties of undefined (reading 'preference')`
+  It comes from the color-mode plugin. Tests still pass. Do not try to fix it.
+- **Never use module-level `ref()` for shared state.** On the server that leaks state between requests. Use Nuxt's `useState()`.
+- **External links always get** `target="_blank"` and `rel="noopener noreferrer"`.
+- **Do not touch** `app/stores/`, `app/middleware/`, `app/pages/dashboard/`, `app/pages/checkout.vue`, `app/pages/payment/`, or anything under `lite_sigma_chat_agent_backend/`.
+
+**Verified environment facts** (probed on 2026-08-12, rely on these):
+
+- `mountSuspended` from `@nuxt/test-utils/runtime` works.
+- `Footer.vue` mounts with no stubs.
+- `MainNavbar.vue` mounts only with `ThemeToggle` stubbed.
+- Vue Router already warns `No match found for location with path "/features"` when the current Footer renders. That is defect B2, confirmed by the router itself.
+
+---
+
+## File Structure
+
+**Create**
+
+| File | Responsibility |
+|---|---|
+| `app/utils/ecosystem.js` | Pure data + `buildProducts(urls)`. No Nuxt context, no side effects. |
+| `app/composables/useEcosystem.js` | Resolves registry URLs from `runtimeConfig.public`. |
+| `app/composables/useDropdown.js` | Open/close state, Escape, click-outside, route-change close, one-open-at-a-time. |
+| `app/components/homepage/NavDropdown.vue` | One dropdown menu. Used four times. |
+| `app/components/homepage/EcosystemStrip.vue` | Landing-page family section. |
+| `test/nuxt/ecosystem.spec.ts` | Registry shape and filtering. |
+| `test/nuxt/navbar.spec.ts` | Nav menus, login dropdown, a11y. |
+| `test/nuxt/footer.spec.ts` | Footer columns, LiteSigma credit, `/features` regression. |
+
+**Modify**
+
+| File | Change |
+|---|---|
+| `nuxt.config.ts` | Three `runtimeConfig.public` URL entries. |
+| `app/components/homepage/MainNavbar.vue` | Menus, login dropdown, mobile accordions. Fixes B3, B4, B5. |
+| `app/components/homepage/Footer.vue` | Registry-driven columns, legal bar. Fixes B1, B2. |
+| `app/components/homepage/ProductSuite.vue` | Heading rename. Fixes B6. |
+| `app/pages/index.vue` | Mount `EcosystemStrip`. |
+| `app/utils/data.js` | Remove `navLinks` once nothing imports it. |
+
+---
+
+## Task 1: The registry and its config
+
+**Files:**
+- Create: `app/utils/ecosystem.js`
+- Create: `app/composables/useEcosystem.js`
+- Modify: `nuxt.config.ts` (the `runtimeConfig.public` block, currently around line 78)
+- Test: `test/nuxt/ecosystem.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `buildProducts({ triviaUrl, labsUrl, blogUrl }) → Product[]`
+  - `Product = { id, name, tagline, href, loginHref, external }` where `id` is one of `'xeliai' | 'trivia' | 'labs' | 'blog'`, `loginHref` is `string | null`, `external` is `boolean`
+  - `menus = { business: MenuItem[], company: MenuItem[] }`, `MenuItem = { label, to, external? }`
+  - `parentCompany = { name, url, linkEnabled }`
+  - `useEcosystem() → { products, loginProducts, menus, parentCompany }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/nuxt/ecosystem.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { buildProducts, menus, parentCompany } from '~/utils/ecosystem'
+
+const urls = {
+  triviaUrl: 'https://trivia.example.com',
+  labsUrl: 'https://labs.example.com',
+  blogUrl: 'https://blog.example.com',
+}
+
+describe('ecosystem registry', () => {
+  it('returns the four products in order', () => {
+    expect(buildProducts(urls).map(p => p.id)).toEqual(['xeliai', 'trivia', 'labs', 'blog'])
+  })
+
+  it('gives every product the required fields', () => {
+    for (const p of buildProducts(urls)) {
+      expect(p.name).toBeTruthy()
+      expect(p.tagline).toBeTruthy()
+      expect(p.href).toBeTruthy()
+      expect(typeof p.external).toBe('boolean')
+    }
+  })
+
+  it('marks only the blog as having no login', () => {
+    const noLogin = buildProducts(urls).filter(p => p.loginHref === null)
+    expect(noLogin.map(p => p.id)).toEqual(['blog'])
+  })
+
+  it('points XeliAI at /products, not the site root', () => {
+    const xeliai = buildProducts(urls).find(p => p.id === 'xeliai')
+    expect(xeliai.href).toBe('/products')
+    expect(xeliai.external).toBe(false)
+  })
+
+  it('builds sibling URLs from the values it is given', () => {
+    const built = buildProducts(urls)
+    expect(built.find(p => p.id === 'trivia').loginHref).toBe('https://trivia.example.com/auth/login')
+    expect(built.find(p => p.id === 'labs').loginHref).toBe('https://labs.example.com')
+    expect(built.find(p => p.id === 'blog').href).toBe('https://blog.example.com')
+  })
+
+  it('uses no em dashes in any user-facing string', () => {
+    const copy = [
+      ...buildProducts(urls).flatMap(p => [p.name, p.tagline]),
+      ...menus.business.map(i => i.label),
+      ...menus.company.map(i => i.label),
+      parentCompany.name,
+    ]
+    for (const s of copy) expect(s).not.toContain('—')
+  })
+
+  it('links menus only to pages that exist', () => {
+    const internal = [...menus.business, ...menus.company]
+      .filter(i => !i.external)
+      .map(i => i.to)
+    const realPages = ['/pricing', '/referrals', '/contact', '/get-started', '/about', '/terms', '/privacy']
+    for (const to of internal) expect(realPages).toContain(to)
+  })
+
+  it('keeps the LiteSigma link disabled while the domain is down', () => {
+    expect(parentCompany.name).toBe('LiteSigma')
+    expect(parentCompany.linkEnabled).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/nuxt/ecosystem.spec.ts`
+Expected: FAIL with `Failed to resolve import "~/utils/ecosystem"`.
+
+- [ ] **Step 3: Write the registry**
+
+Create `app/utils/ecosystem.js`:
+
+```js
+// ~/utils/ecosystem.js
+// Single source of truth for the XeliAI product family.
+// The navbar, mobile drawer, login menu and footer all read from here.
+// Sibling URLs are injected so this file stays pure and testable.
+
+export function buildProducts({ triviaUrl, labsUrl, blogUrl }) {
+  return [
+    {
+      id: 'xeliai',
+      name: 'XeliAI',
+      tagline: 'AI chatbot trained on your business data',
+      href: '/products',
+      loginHref: '/login',
+      external: false,
+    },
+    {
+      id: 'trivia',
+      name: 'XeliAI Trivia',
+      tagline: 'Turn any study material into adaptive practice',
+      href: triviaUrl,
+      loginHref: `${triviaUrl}/auth/login`,
+      external: true,
+    },
+    {
+      id: 'labs',
+      name: 'XeliAI Labs',
+      tagline: 'Courses, mentorship and talent',
+      // Labs has no working auth yet, so this points at its home page.
+      loginHref: labsUrl,
+      href: labsUrl,
+      external: true,
+    },
+    {
+      id: 'blog',
+      name: 'XeliAI Blog',
+      tagline: 'Product news and writing',
+      href: blogUrl,
+      loginHref: null, // no login: excluded from the login menu
+      external: true,
+    },
+  ]
+}
+
+export const menus = {
+  business: [
+    { label: 'Pricing', to: '/pricing' },
+    { label: 'Referral Program', to: '/referrals' },
+    { label: 'Talk to sales', to: '/contact' },
+    { label: 'Get started', to: '/get-started' },
+  ],
+  company: [
+    { label: 'About', to: '/about' },
+    { label: 'Contact', to: '/contact' },
+    { label: 'Terms', to: '/terms' },
+    { label: 'Privacy', to: '/privacy' },
+  ],
+}
+
+export const parentCompany = {
+  name: 'LiteSigma',
+  url: 'https://litesigma.com',
+  // litesigma.com does not resolve as of 2026-08-12. Flip to true when it does.
+  linkEnabled: false,
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run test/nuxt/ecosystem.spec.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Add the runtime config**
+
+In `nuxt.config.ts`, inside the existing `runtimeConfig.public` object, add three entries alongside `apiBase`:
+
+```ts
+      triviaUrl: process.env.NUXT_PUBLIC_TRIVIA_URL || "https://trivia.xeliai.com",
+      labsUrl: process.env.NUXT_PUBLIC_LABS_URL || "https://labs.xeliai.com",
+      blogUrl: process.env.NUXT_PUBLIC_BLOG_URL || "https://blog.xeliai.com",
+```
+
+Do not remove or reorder anything already in that block.
+
+- [ ] **Step 6: Write the composable**
+
+Create `app/composables/useEcosystem.js`:
+
+```js
+// ~/composables/useEcosystem.js
+import { buildProducts, menus, parentCompany } from '~/utils/ecosystem'
+
+export function useEcosystem() {
+  const config = useRuntimeConfig()
+
+  const products = buildProducts({
+    triviaUrl: config.public.triviaUrl,
+    labsUrl: config.public.labsUrl,
+    blogUrl: config.public.blogUrl,
+  })
+
+  return {
+    products,
+    // Products you can actually log in to. The blog has loginHref: null.
+    loginProducts: products.filter(p => p.loginHref !== null),
+    menus,
+    parentCompany,
+  }
+}
+```
+
+- [ ] **Step 7: Run the whole suite**
+
+Run: `npx vitest run`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/utils/ecosystem.js app/composables/useEcosystem.js nuxt.config.ts test/nuxt/ecosystem.spec.ts
+git commit -m "feat(nav): add the ecosystem product registry
+
+Single source of truth for the product family, consumed by the navbar,
+mobile drawer, login menu and footer. Sibling URLs come from
+runtimeConfig.public so a staging build does not link into production."
+```
+
+---
+
+## Task 2: The dropdown composable
+
+**Files:**
+- Create: `app/composables/useDropdown.js`
+- Test: `test/nuxt/dropdown.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `useDropdown(id: string) → { isOpen: ComputedRef<boolean>, open(), close(), toggle(), closeAndRefocus(), triggerRef: Ref, panelRef: Ref }`
+
+Shared open state lives in `useState('nav:openDropdown')`, which is SSR-safe and gives one-open-at-a-time for free.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/nuxt/dropdown.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineComponent, h } from 'vue'
+import { useDropdown } from '~/composables/useDropdown'
+
+// The returned object is flattened deliberately. Vue only unwraps refs
+// returned at the top level of setup, so `this.a.isOpen` would stay a
+// Ref and read as truthy forever.
+const Harness = defineComponent({
+  setup() {
+    const a = useDropdown('a')
+    const b = useDropdown('b')
+    return {
+      aOpen: a.isOpen,
+      bOpen: b.isOpen,
+      aToggle: a.toggle,
+      bToggle: b.toggle,
+    }
+  },
+  render() {
+    return h('div', [
+      h('button', { id: 'ta', onClick: () => this.aToggle() }, 'A'),
+      h('button', { id: 'tb', onClick: () => this.bToggle() }, 'B'),
+      this.aOpen ? h('div', { id: 'pa' }, 'panel a') : null,
+      this.bOpen ? h('div', { id: 'pb' }, 'panel b') : null,
+    ])
+  },
+})
+
+describe('useDropdown', () => {
+  it('starts closed', async () => {
+    const w = await mountSuspended(Harness)
+    expect(w.find('#pa').exists()).toBe(false)
+  })
+
+  it('opens on toggle', async () => {
+    const w = await mountSuspended(Harness)
+    await w.find('#ta').trigger('click')
+    expect(w.find('#pa').exists()).toBe(true)
+  })
+
+  it('closes on a second toggle', async () => {
+    const w = await mountSuspended(Harness)
+    await w.find('#ta').trigger('click')
+    await w.find('#ta').trigger('click')
+    expect(w.find('#pa').exists()).toBe(false)
+  })
+
+  it('opening one closes the other', async () => {
+    const w = await mountSuspended(Harness)
+    await w.find('#ta').trigger('click')
+    await w.find('#tb').trigger('click')
+    expect(w.find('#pa').exists()).toBe(false)
+    expect(w.find('#pb').exists()).toBe(true)
+  })
+
+  it('closes on Escape', async () => {
+    const w = await mountSuspended(Harness)
+    await w.find('#ta').trigger('click')
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await w.vm.$nextTick()
+    expect(w.find('#pa').exists()).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/nuxt/dropdown.spec.ts`
+Expected: FAIL with `useDropdown is not defined`.
+
+- [ ] **Step 3: Write the composable**
+
+Create `app/composables/useDropdown.js`:
+
+```js
+// ~/composables/useDropdown.js
+// Shared open/close behaviour for every nav dropdown.
+// Open state lives in useState, not a module-level ref, because a
+// module-level ref leaks state between requests during SSR.
+import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
+
+export function useDropdown(id) {
+  const openId = useState('nav:openDropdown', () => null)
+  const triggerRef = ref(null)
+  const panelRef = ref(null)
+
+  const isOpen = computed(() => openId.value === id)
+
+  const open = () => { openId.value = id }
+  const close = () => { if (openId.value === id) openId.value = null }
+  const toggle = () => (isOpen.value ? close() : open())
+
+  // Used by Escape and by selecting an item: focus must go back to the
+  // trigger, or keyboard users are dumped at the top of the document.
+  const closeAndRefocus = () => {
+    const el = triggerRef.value?.$el ?? triggerRef.value
+    close()
+    el?.focus?.()
+  }
+
+  const onDocumentClick = (event) => {
+    if (!isOpen.value) return
+    const trigger = triggerRef.value?.$el ?? triggerRef.value
+    const panel = panelRef.value?.$el ?? panelRef.value
+    if (trigger?.contains(event.target)) return
+    if (panel?.contains(event.target)) return
+    close()
+  }
+
+  const onKeydown = (event) => {
+    if (!isOpen.value) return
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeAndRefocus()
+    }
+  }
+
+  onMounted(() => {
+    document.addEventListener('click', onDocumentClick)
+    document.addEventListener('keydown', onKeydown)
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('click', onDocumentClick)
+    document.removeEventListener('keydown', onKeydown)
+  })
+
+  // Navigating away must not leave a menu hanging open.
+  const router = useRouter()
+  watch(() => router.currentRoute.value.fullPath, () => close())
+
+  return { isOpen, open, close, toggle, closeAndRefocus, triggerRef, panelRef }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run test/nuxt/dropdown.spec.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/composables/useDropdown.js test/nuxt/dropdown.spec.ts
+git commit -m "feat(nav): add useDropdown composable
+
+Shared open/close, Escape-to-close-and-refocus, click-outside and
+route-change handling for all four nav dropdowns. Replaces the single
+hardcoded document.querySelector('[data-profile-menu]') selector, which
+closed the wrong menu once more than one existed.
+
+Open state uses useState rather than a module-level ref, which would
+leak between requests during SSR."
+```
+
+---
+
+## Task 3: The NavDropdown component
+
+**Files:**
+- Create: `app/components/homepage/NavDropdown.vue`
+- Test: `test/nuxt/navdropdown.spec.ts`
+
+**Interfaces:**
+- Consumes: `useDropdown` from Task 2.
+- Produces: a component taking props `id: string`, `label: string`, `items: Array<{ label, to, external?, tagline? }>`, `align?: 'start' | 'end'` (default `'start'`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/nuxt/navdropdown.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import NavDropdown from '~/components/homepage/NavDropdown.vue'
+
+const items = [
+  { label: 'Internal', to: '/pricing' },
+  { label: 'External', to: 'https://example.com', external: true, tagline: 'A tagline' },
+]
+
+describe('NavDropdown', () => {
+  it('renders the label and stays closed initially', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    expect(w.text()).toContain('Products')
+    expect(w.find('[role="menu"]').exists()).toBe(false)
+  })
+
+  it('sets aria attributes on the trigger', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    const trigger = w.find('button')
+    expect(trigger.attributes('aria-haspopup')).toBe('menu')
+    expect(trigger.attributes('aria-expanded')).toBe('false')
+  })
+
+  it('flips aria-expanded and shows the menu on click', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    await w.find('button').trigger('click')
+    expect(w.find('button').attributes('aria-expanded')).toBe('true')
+    expect(w.find('[role="menu"]').exists()).toBe(true)
+  })
+
+  it('renders every item with role menuitem', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    await w.find('button').trigger('click')
+    expect(w.findAll('[role="menuitem"]')).toHaveLength(2)
+  })
+
+  it('gives external links target and rel', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    await w.find('button').trigger('click')
+    const external = w.findAll('[role="menuitem"]')[1]
+    expect(external.attributes('target')).toBe('_blank')
+    expect(external.attributes('rel')).toBe('noopener noreferrer')
+  })
+
+  it('does not put target or rel on internal links', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    await w.find('button').trigger('click')
+    const internal = w.findAll('[role="menuitem"]')[0]
+    expect(internal.attributes('target')).toBeUndefined()
+  })
+
+  it('renders taglines when present', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    await w.find('button').trigger('click')
+    expect(w.text()).toContain('A tagline')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/nuxt/navdropdown.spec.ts`
+Expected: FAIL with `Failed to resolve import "~/components/homepage/NavDropdown.vue"`.
+
+- [ ] **Step 3: Write the component**
+
+Create `app/components/homepage/NavDropdown.vue`:
+
+```vue
+<!-- components/homepage/NavDropdown.vue -->
+<script setup>
+import { ChevronDown } from 'lucide-vue-next'
+import { useDropdown } from '~/composables/useDropdown'
+
+const props = defineProps({
+  id: { type: String, required: true },
+  label: { type: String, required: true },
+  items: { type: Array, required: true },
+  align: { type: String, default: 'start' },
+})
+
+const { isOpen, toggle, close, closeAndRefocus, triggerRef, panelRef } = useDropdown(props.id)
+
+// Roving focus through the menu with the arrow keys.
+const onPanelKeydown = (event) => {
+  const focusables = Array.from(panelRef.value?.querySelectorAll('[role="menuitem"]') ?? [])
+  if (!focusables.length) return
+  const current = focusables.indexOf(document.activeElement)
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    focusables[(current + 1) % focusables.length].focus()
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    focusables[(current - 1 + focusables.length) % focusables.length].focus()
+  } else if (event.key === 'Home') {
+    event.preventDefault()
+    focusables[0].focus()
+  } else if (event.key === 'End') {
+    event.preventDefault()
+    focusables[focusables.length - 1].focus()
+  } else if (event.key === 'Tab') {
+    close()
+  }
+}
+</script>
+
+<template>
+  <div class="relative">
+    <button
+      ref="triggerRef"
+      type="button"
+      class="flex items-center gap-1 px-2 py-1 rounded-md font-medium text-gray-600 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors duration-200"
+      aria-haspopup="menu"
+      :aria-expanded="isOpen ? 'true' : 'false'"
+      @click.stop="toggle"
+    >
+      {{ label }}
+      <ChevronDown
+        class="w-4 h-4 transition-transform duration-200"
+        :class="{ 'rotate-180': isOpen }"
+        aria-hidden="true"
+      />
+    </button>
+
+    <Transition
+      enter-active-class="transition ease-out duration-100"
+      enter-from-class="transform opacity-0 scale-95"
+      enter-to-class="transform opacity-100 scale-100"
+      leave-active-class="transition ease-in duration-75"
+      leave-from-class="transform opacity-100 scale-100"
+      leave-to-class="transform opacity-0 scale-95"
+    >
+      <div
+        v-if="isOpen"
+        ref="panelRef"
+        role="menu"
+        :aria-label="label"
+        class="absolute mt-2 w-72 rounded-xl shadow-lg bg-white dark:bg-slate-800 ring-1 ring-black/5 border border-gray-100 dark:border-slate-700 p-2 z-50"
+        :class="align === 'end' ? 'right-0' : 'left-0'"
+        @keydown="onPanelKeydown"
+      >
+        <component
+          :is="item.external ? 'a' : 'NuxtLink'"
+          v-for="item in items"
+          :key="item.label"
+          role="menuitem"
+          :href="item.external ? item.to : undefined"
+          :to="item.external ? undefined : item.to"
+          :target="item.external ? '_blank' : undefined"
+          :rel="item.external ? 'noopener noreferrer' : undefined"
+          class="block px-3 py-2 rounded-lg text-sm text-gray-700 dark:text-gray-200 hover:bg-purple-50 dark:hover:bg-slate-700 hover:text-purple-600 transition-colors"
+          @click="closeAndRefocus"
+        >
+          <span class="font-medium">{{ item.label }}</span>
+          <span v-if="item.tagline" class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {{ item.tagline }}
+          </span>
+        </component>
+      </div>
+    </Transition>
+  </div>
+</template>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run test/nuxt/navdropdown.spec.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/homepage/NavDropdown.vue test/nuxt/navdropdown.spec.ts
+git commit -m "feat(nav): add NavDropdown component
+
+One accessible dropdown used four times: Products, Business, Company and
+Log in. Arrow key roving focus, aria-haspopup and aria-expanded on the
+trigger, role=menu and role=menuitem on the panel, and target plus rel on
+every external link."
+```
+
+---
+
+## Task 4: Rewire the desktop navbar
+
+**Files:**
+- Modify: `app/components/homepage/MainNavbar.vue`
+- Test: `test/nuxt/navbar.spec.ts`
+
+**Interfaces:**
+- Consumes: `useEcosystem()` (Task 1), `NavDropdown` (Task 3).
+- Produces: nothing consumed by later tasks.
+
+Replace the desktop `navLinks` loop with three `NavDropdown`s plus a flat Pricing link. Replace the logged-out `Get Started` block with a `Log in` dropdown followed by `Get Started`. Keep the authenticated profile menu working, adding the sibling products beneath a divider. Delete the `handleClickOutside` function and its `onMounted`/`onUnmounted` listeners; `useDropdown` owns that now.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/nuxt/navbar.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import MainNavbar from '~/components/homepage/MainNavbar.vue'
+
+// ThemeToggle reads colorMode.value, and @nuxtjs/color-mode does not
+// initialise in the test environment, so it must be stubbed or the
+// render throws.
+const mount = () => mountSuspended(MainNavbar, {
+  global: { stubs: { ThemeToggle: true } },
+})
+
+describe('MainNavbar', () => {
+  it('renders the three menus and a flat Pricing link', async () => {
+    const w = await mount()
+    const triggers = w.findAll('[aria-haspopup="menu"]').map(b => b.text())
+    expect(triggers.some(t => t.includes('Products'))).toBe(true)
+    expect(triggers.some(t => t.includes('Business'))).toBe(true)
+    expect(triggers.some(t => t.includes('Company'))).toBe(true)
+    expect(w.html()).toContain('/pricing')
+  })
+
+  it('lists all four products in the Products menu', async () => {
+    const w = await mount()
+    const products = w.findAll('[aria-haspopup="menu"]').find(b => b.text().includes('Products'))
+    await products.trigger('click')
+    const text = w.find('[role="menu"]').text()
+    expect(text).toContain('XeliAI Trivia')
+    expect(text).toContain('XeliAI Labs')
+    expect(text).toContain('XeliAI Blog')
+  })
+
+  it('offers three logins and never the blog', async () => {
+    const w = await mount()
+    const login = w.findAll('[aria-haspopup="menu"]').find(b => b.text().includes('Log in'))
+    await login.trigger('click')
+    const menu = w.find('[role="menu"]')
+    expect(menu.findAll('[role="menuitem"]')).toHaveLength(3)
+    expect(menu.text()).not.toContain('Blog')
+  })
+
+  it('keeps the Get Started call to action', async () => {
+    const w = await mount()
+    expect(w.html()).toContain('/get-started')
+    expect(w.text()).toContain('Get Started')
+  })
+
+  it('uses no em dashes anywhere in the rendered nav', async () => {
+    const w = await mount()
+    expect(w.text()).not.toContain('—')
+  })
+
+  it('leaves Pricing as the only flat desktop link', async () => {
+    const w = await mount()
+    // Scoped to the desktop nav on purpose. The mobile drawer keeps its
+    // accordion panels in the DOM via v-show, so wrapper.text() sees
+    // collapsed items and a whole-component assertion would be a lie.
+    const desktop = w.find('[data-desktop-nav]')
+    expect(desktop.findAll('a').map(a => a.text())).toEqual(['Pricing'])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/nuxt/navbar.spec.ts`
+Expected: FAIL — no element matches `[aria-haspopup="menu"]` with text `Products`.
+
+- [ ] **Step 3: Update the script block**
+
+In `app/components/homepage/MainNavbar.vue`, replace the whole `<script setup>` block with:
+
+```vue
+<script setup>
+import { ref, computed } from 'vue'
+import { Menu, X, User, LogOut, LayoutDashboard } from 'lucide-vue-next'
+import { useAuthStore } from '~/stores/authStore'
+import { useEcosystem } from '~/composables/useEcosystem'
+import { useDropdown } from '~/composables/useDropdown'
+import ThemeToggle from '../ui/ThemeToggle.vue'
+import NavDropdown from './NavDropdown.vue'
+
+const authStore = useAuthStore()
+const router = useRouter()
+const navOpen = ref(false)
+
+const { products, loginProducts, menus } = useEcosystem()
+
+const isAuthenticated = computed(() => authStore.isLoggedIn)
+const user = computed(() => authStore.user)
+
+// Products carry taglines; the other menus are plain link lists.
+const productItems = products.map(p => ({
+  label: p.name,
+  to: p.href,
+  external: p.external,
+  tagline: p.tagline,
+}))
+
+// Every product you can log in to. The blog has loginHref: null, so it
+// is absent here by construction.
+const loginItems = loginProducts.map(p => ({
+  label: p.name,
+  to: p.loginHref,
+  external: p.external,
+}))
+
+// Sibling products shown under the profile menu when signed in. This
+// menu knows nothing about their sessions, only where they live.
+const siblingItems = products.filter(p => p.external).map(p => ({
+  label: p.name,
+  to: p.href,
+  external: true,
+}))
+
+const openNav = () => (navOpen.value = true)
+const closeNav = () => (navOpen.value = false)
+
+// Destructured into top-level consts on purpose. Vue's string template
+// ref (ref="name") only binds to a top-level ref, so ref="profile.triggerRef"
+// would silently never bind.
+const {
+  isOpen: profileOpen,
+  toggle: toggleProfile,
+  close: closeProfile,
+  triggerRef: profileTriggerRef,
+  panelRef: profilePanelRef,
+} = useDropdown('profile')
+
+const handleLogout = async () => {
+  await authStore.logout()
+  closeProfile()
+  router.push('/login')
+}
+
+const goToDashboard = () => {
+  closeProfile()
+  router.push('/dashboard')
+}
+
+// Mobile accordion state.
+const openSection = ref(null)
+const toggleSection = (key) => (openSection.value = openSection.value === key ? null : key)
+</script>
+```
+
+Note what disappeared: the `navLinks` import, `profileMenuOpen`, `toggleProfileMenu`, `handleClickOutside`, `ChevronDown`, and both lifecycle hooks. `useDropdown` and `NavDropdown` own all of it now.
+
+- [ ] **Step 4: Replace the desktop nav markup**
+
+In the template, replace the `<!-- Desktop Nav -->` block (the `div` containing the `v-for` over `navLinks`) with:
+
+```vue
+      <!-- Desktop Nav -->
+      <div data-desktop-nav class="hidden lg:flex items-center space-x-6">
+        <NavDropdown id="products" label="Products" :items="productItems" />
+        <NavDropdown id="business" label="Business" :items="menus.business" />
+        <NavDropdown id="company" label="Company" :items="menus.company" />
+        <NuxtLink
+          to="/pricing"
+          class="px-2 py-1 rounded-md font-medium text-gray-600 dark:text-gray-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors duration-200"
+        >
+          Pricing
+        </NuxtLink>
+      </div>
+```
+
+- [ ] **Step 5: Replace the logged-out button with the login dropdown**
+
+Replace the `<!-- Get Started Button -->` `NuxtLink` block with:
+
+```vue
+        <!-- Log in menu + primary CTA -->
+        <div v-else class="hidden lg:flex items-center gap-3">
+          <NavDropdown id="login" label="Log in" :items="loginItems" align="end" />
+          <NuxtLink to="/get-started">
+            <button
+              class="px-8 py-3 nav_primary_btn text-white rounded-lg transition-transform hover:-translate-y-0.5 shadow-lg shadow-purple-500/20"
+            >
+              Get Started
+            </button>
+          </NuxtLink>
+        </div>
+```
+
+- [ ] **Step 6: Update the authenticated profile menu**
+
+In the authenticated block: change `@click.stop="toggleProfileMenu"` to `@click.stop="toggleProfile"`, add `ref="profileTriggerRef"` to that button, replace both `v-if="profileMenuOpen"` and `:class="{ 'rotate-180': profileMenuOpen }"` with `profileOpen`, replace `:aria-expanded="profileMenuOpen"` with `:aria-expanded="profileOpen ? 'true' : 'false'"`, add `ref="profilePanelRef"` to the panel div, and add this divider and sibling list directly after the Logout button, still inside the panel's `<div class="p-2">`:
+
+```vue
+                <div class="my-2 border-t border-gray-100 dark:border-slate-700"></div>
+                <p class="px-4 pb-1 text-xs font-semibold uppercase tracking-wide text-gray-400">
+                  More from XeliAI
+                </p>
+                <a
+                  v-for="item in siblingItems"
+                  :key="item.label"
+                  :href="item.to"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="w-full flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-purple-50 dark:hover:bg-slate-700 hover:text-purple-600 rounded-md transition-colors"
+                  role="menuitem"
+                >
+                  {{ item.label }}
+                </a>
+```
+
+Also remove `data-profile-menu` from the wrapper div; nothing reads it now.
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `npx vitest run test/nuxt/navbar.spec.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 8: Verify nothing else imports navLinks**
+
+Run: `npx vitest run` then check the app builds.
+Run: `npx nuxt build`
+Expected: build succeeds. If it fails on a missing `navLinks` import, find the importer and migrate it before continuing.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/components/homepage/MainNavbar.vue test/nuxt/navbar.spec.ts
+git commit -m "feat(nav): OpenAI-style product, business and company menus
+
+Seven flat links become three dropdowns plus Pricing, which stays top
+level because it is the highest intent page on the site. Adds a Log in
+dropdown routing to each product's own login, mirroring how openai.com
+sends people to chatgpt.com and platform.openai.com separately.
+
+The menu never implies knowledge of a Trivia or Labs session: authStore
+holds a XeliAI token only, and those are separate auth systems on
+separate domains.
+
+Removes the dead ChevronDown affordance, which rendered for a link.more
+field that was empty on every entry and had no dropdown behind it."
+```
+
+---
+
+## Task 5: The mobile drawer
+
+**Files:**
+- Modify: `app/components/homepage/MainNavbar.vue` (the `<aside>` drawer only)
+- Test: `test/nuxt/navbar-mobile.spec.ts`
+
+**Interfaces:**
+- Consumes: `productItems`, `loginItems`, `menus`, `openSection`, `toggleSection` from Task 4's script block.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/nuxt/navbar-mobile.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import MainNavbar from '~/components/homepage/MainNavbar.vue'
+
+const mount = () => mountSuspended(MainNavbar, {
+  global: { stubs: { ThemeToggle: true } },
+})
+
+describe('MainNavbar mobile drawer', () => {
+  it('renders a section button per menu', async () => {
+    const w = await mount()
+    const sections = w.findAll('[data-drawer-section]').map(b => b.text())
+    expect(sections).toEqual(['Products', 'Business', 'Company'])
+  })
+
+  it('expands a section on click', async () => {
+    const w = await mount()
+    const products = w.findAll('[data-drawer-section]')[0]
+    expect(products.attributes('aria-expanded')).toBe('false')
+    await products.trigger('click')
+    expect(products.attributes('aria-expanded')).toBe('true')
+    expect(w.find('#drawer-panel-products').text()).toContain('XeliAI Trivia')
+  })
+
+  it('collapses the open section when another opens', async () => {
+    const w = await mount()
+    const [products, business] = w.findAll('[data-drawer-section]')
+    await products.trigger('click')
+    await business.trigger('click')
+    expect(products.attributes('aria-expanded')).toBe('false')
+    expect(business.attributes('aria-expanded')).toBe('true')
+  })
+
+  it('offers the logins in the drawer', async () => {
+    const w = await mount()
+    expect(w.find('[data-drawer-logins]').findAll('a')).toHaveLength(3)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/nuxt/navbar-mobile.spec.ts`
+Expected: FAIL — no elements match `[data-drawer-section]`.
+
+- [ ] **Step 3: Replace the drawer link list with accordions**
+
+Inside the `<aside>`, replace the `<div class="flex flex-col space-y-6">` block that loops `navLinks` with:
+
+```vue
+        <div class="flex flex-col space-y-2">
+          <div v-for="section in drawerSections" :key="section.key" class="border-b border-white/20 pb-2">
+            <button
+              type="button"
+              data-drawer-section
+              class="w-full flex items-center justify-between text-lg sm:text-2xl font-semibold py-2"
+              :aria-expanded="openSection === section.key ? 'true' : 'false'"
+              :aria-controls="`drawer-panel-${section.key}`"
+              @click="toggleSection(section.key)"
+            >
+              {{ section.label }}
+              <ChevronDown
+                class="w-5 h-5 transition-transform"
+                :class="{ 'rotate-180': openSection === section.key }"
+                aria-hidden="true"
+              />
+            </button>
+            <div
+              v-show="openSection === section.key"
+              :id="`drawer-panel-${section.key}`"
+              class="flex flex-col space-y-3 pb-3 pl-2"
+            >
+              <component
+                :is="item.external ? 'a' : 'NuxtLink'"
+                v-for="item in section.items"
+                :key="item.label"
+                :href="item.external ? item.to : undefined"
+                :to="item.external ? undefined : item.to"
+                :target="item.external ? '_blank' : undefined"
+                :rel="item.external ? 'noopener noreferrer' : undefined"
+                class="text-base text-white/80 hover:text-white transition-colors"
+                @click="closeNav"
+              >
+                {{ item.label }}
+              </component>
+            </div>
+          </div>
+
+          <NuxtLink
+            to="/pricing"
+            class="text-lg sm:text-2xl font-semibold border-b border-white/20 py-2 hover:border-white transition-all"
+            @click="closeNav"
+          >
+            Pricing
+          </NuxtLink>
+        </div>
+```
+
+- [ ] **Step 4: Add the drawer sections and login block**
+
+Add to the script block, after `siblingItems`:
+
+```js
+const drawerSections = [
+  { key: 'products', label: 'Products', items: productItems },
+  { key: 'business', label: 'Business', items: menus.business },
+  { key: 'company', label: 'Company', items: menus.company },
+]
+```
+
+Re-add `ChevronDown` to the `lucide-vue-next` import in the script block.
+
+Then handle the drawer's bottom block. The `v-else` currently sits *on* the `NuxtLink`, so nothing can be inserted "inside" it. Replace this whole element:
+
+```vue
+          <NuxtLink v-else to="/get-started" @click="closeNav" class="block">
+            <button class="w-full px-8 py-3 bg-white text-[#9E4CFF] font-bold text-base sm:text-lg rounded-xl shadow-lg hover:bg-gray-50 transition-colors">
+              Get Started
+            </button>
+          </NuxtLink>
+```
+
+with a wrapper that carries the `v-else` and holds both the logins and the button:
+
+```vue
+          <div v-else>
+            <div data-drawer-logins class="mb-4 space-y-2">
+              <p class="text-xs font-semibold uppercase tracking-wide text-white/60">Log in to</p>
+              <a
+                v-for="item in loginItems"
+                :key="item.label"
+                :href="item.to"
+                :target="item.external ? '_blank' : undefined"
+                :rel="item.external ? 'noopener noreferrer' : undefined"
+                class="block text-base text-white/90 hover:text-white transition-colors"
+                @click="closeNav"
+              >
+                {{ item.label }}
+              </a>
+            </div>
+
+            <NuxtLink to="/get-started" class="block" @click="closeNav">
+              <button
+                class="w-full px-8 py-3 bg-white text-[#9E4CFF] font-bold text-base sm:text-lg rounded-xl shadow-lg hover:bg-gray-50 transition-colors"
+              >
+                Get Started
+              </button>
+            </NuxtLink>
+          </div>
+```
+
+- [ ] **Step 5: Add the focus trap**
+
+The drawer sets `aria-modal="true"` but focus currently walks out of it. Add to the script block:
+
+```js
+const drawerRef = ref(null)
+
+// aria-modal is a promise to keyboard users. Without a trap, focus walks
+// straight out of the drawer into the page behind it.
+const onDrawerKeydown = (event) => {
+  if (event.key === 'Escape') { closeNav(); return }
+  if (event.key !== 'Tab') return
+
+  const focusables = drawerRef.value?.querySelectorAll(
+    'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  )
+  if (!focusables?.length) return
+
+  const first = focusables[0]
+  const last = focusables[focusables.length - 1]
+
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+```
+
+Then add `ref="drawerRef"` and `@keydown="onDrawerKeydown"` to the `<aside>` element.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npx vitest run test/nuxt/navbar-mobile.spec.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/components/homepage/MainNavbar.vue test/nuxt/navbar-mobile.spec.ts
+git commit -m "feat(nav): collapsible sections and logins in the mobile drawer
+
+The three menus become accordions and the login links sit above the Get
+Started button.
+
+Also adds a focus trap. The drawer already declared aria-modal=true,
+which is a promise to keyboard users that focus stays inside it, but
+there was no trap, so focus walked out into the page behind."
+```
+
+---
+
+## Task 6: The footer
+
+**Files:**
+- Modify: `app/components/homepage/Footer.vue`
+- Test: `test/nuxt/footer.spec.ts`
+
+**Interfaces:**
+- Consumes: `useEcosystem()` from Task 1.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/nuxt/footer.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import Footer from '~/components/homepage/Footer.vue'
+
+describe('Footer', () => {
+  it('does not link to the non-existent /features page', async () => {
+    const w = await mountSuspended(Footer)
+    expect(w.html()).not.toContain('/features')
+  })
+
+  it('renders the four column headings', async () => {
+    const w = await mountSuspended(Footer)
+    const headings = w.findAll('h3').map(h => h.text())
+    expect(headings).toEqual(['Products', 'Business', 'Company', 'Legal'])
+  })
+
+  it('lists every product in the Products column', async () => {
+    const w = await mountSuspended(Footer)
+    const text = w.text()
+    expect(text).toContain('XeliAI Trivia')
+    expect(text).toContain('XeliAI Labs')
+    expect(text).toContain('XeliAI Blog')
+  })
+
+  it('credits LiteSigma as plain text while the domain is down', async () => {
+    const w = await mountSuspended(Footer)
+    expect(w.text()).toContain('Powered by LiteSigma')
+    expect(w.find('[data-parent-company]').element.tagName).not.toBe('A')
+  })
+
+  it('mentions LiteSigma exactly once', async () => {
+    const w = await mountSuspended(Footer)
+    expect(w.text().match(/LiteSigma/g)).toHaveLength(1)
+  })
+
+  it('gives every external link target and rel', async () => {
+    const w = await mountSuspended(Footer)
+    for (const a of w.findAll('a[target="_blank"]')) {
+      expect(a.attributes('rel')).toBe('noopener noreferrer')
+    }
+  })
+
+  it('uses no em dashes', async () => {
+    const w = await mountSuspended(Footer)
+    expect(w.text()).not.toContain('—')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/nuxt/footer.spec.ts`
+Expected: FAIL on the `/features` assertion and on the headings assertion.
+
+- [ ] **Step 3: Rewrite the footer script block**
+
+Replace the `<script setup>` block in `app/components/homepage/Footer.vue` with:
+
+```vue
+<script setup>
+import { Facebook, Instagram, Linkedin } from 'lucide-vue-next'
+import { useEcosystem } from '~/composables/useEcosystem'
+
+const { products, menus, parentCompany } = useEcosystem()
+
+const columns = [
+  {
+    heading: 'Products',
+    items: products.map(p => ({ label: p.name, to: p.href, external: p.external })),
+  },
+  { heading: 'Business', items: menus.business },
+  { heading: 'Company', items: menus.company.filter(i => !['Terms', 'Privacy'].includes(i.label)) },
+  { heading: 'Legal', items: menus.company.filter(i => ['Terms', 'Privacy'].includes(i.label)) },
+]
+</script>
+```
+
+- [ ] **Step 4: Replace the footer columns markup**
+
+Delete the orphaned `<div class="space-y-5">` block containing the `Product` heading and the `/features` link. It sits between `.brand-col` and `.nav-columns`, is a flex child rather than a grid cell, and links to a page that does not exist.
+
+Then replace the entire `<div class="nav-columns">` block with:
+
+```vue
+          <div class="nav-columns">
+            <div v-for="column in columns" :key="column.heading" class="nav-col">
+              <h3 class="nav-heading">{{ column.heading }}</h3>
+              <nav class="nav-links">
+                <component
+                  :is="item.external ? 'a' : 'NuxtLink'"
+                  v-for="item in column.items"
+                  :key="item.label"
+                  :href="item.external ? item.to : undefined"
+                  :to="item.external ? undefined : item.to"
+                  :target="item.external ? '_blank' : undefined"
+                  :rel="item.external ? 'noopener noreferrer' : undefined"
+                  class="nav-link"
+                  :class="{ 'nav-link--external': item.external }"
+                >
+                  {{ item.label }}
+                  <svg
+                    v-if="item.external"
+                    class="ext-icon"
+                    viewBox="0 0 12 12"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M2.5 9.5L9.5 2.5M9.5 2.5H5M9.5 2.5V7"
+                      stroke="currentColor"
+                      stroke-width="1.2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </component>
+              </nav>
+            </div>
+          </div>
+```
+
+This removes the old `Xeliai Ecosystem` column, whose job the Products column now does from shared data, and the `Support` column, whose `Help Center` link pointed at `/contact` and promised a page that does not exist.
+
+- [ ] **Step 5: Add the LiteSigma credit to the legal bar**
+
+Replace the `<div class="legal-bar">` contents with:
+
+```vue
+          <div class="legal-bar">
+            <span class="copyright">© {{ new Date().getFullYear() }} XELI AI · ALL RIGHTS RESERVED</span>
+
+            <a
+              v-if="parentCompany.linkEnabled"
+              data-parent-company
+              :href="parentCompany.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="powered-by"
+            >
+              Powered by {{ parentCompany.name }}
+            </a>
+            <span v-else data-parent-company class="powered-by">
+              Powered by {{ parentCompany.name }}
+            </span>
+
+            <div class="legal-links">
+              <NuxtLink to="/terms" class="legal-link">Terms &amp; Conditions</NuxtLink>
+              <NuxtLink to="/about" class="legal-link">About</NuxtLink>
+            </div>
+          </div>
+```
+
+Add to the scoped style block:
+
+```css
+.powered-by {
+  font-size: 12px;
+  color: #6B7280;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+}
+a.powered-by:hover {
+  color: #9CA3AF;
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npx vitest run test/nuxt/footer.spec.ts`
+Expected: PASS, 7 tests. The `No match found for location with path "/features"` router warning should be gone from the output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/components/homepage/Footer.vue test/nuxt/footer.spec.ts
+git commit -m "feat(nav): rebuild the footer from the product registry
+
+Columns now come from the same registry as the nav, so the two cannot
+drift.
+
+Fixes an orphaned Product column that sat outside the grid as a flex
+child, styled with raw Tailwind while every neighbour used scoped CSS,
+and linked to /features, which has no page. Vue Router was warning about
+it on every render.
+
+Retires the Support column, whose Help Center link pointed at /contact,
+and the Ecosystem column, now covered by Products.
+
+Adds the Powered by LiteSigma credit, rendered as plain text because
+litesigma.com does not currently resolve. Set parentCompany.linkEnabled
+to true when it does."
+```
+
+---
+
+## Task 7: Rename the on-page product section
+
+**Files:**
+- Modify: `app/components/homepage/ProductSuite.vue`
+- Test: `test/nuxt/productsuite.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+The section describes features *inside* XeliAI, so it must stop calling them products now that a Products menu means sibling apps.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/nuxt/productsuite.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import ProductSuite from '~/components/homepage/ProductSuite.vue'
+
+describe('ProductSuite', () => {
+  it('no longer calls the section Product Suite', async () => {
+    const w = await mountSuspended(ProductSuite)
+    expect(w.find('h2').text()).toBe('What XeliAI does')
+  })
+
+  it('has no dead filter buttons', async () => {
+    const w = await mountSuspended(ProductSuite)
+    const labels = w.findAll('button').map(b => b.text())
+    expect(labels).not.toContain('All')
+    expect(labels).not.toContain('Support')
+    expect(labels).not.toContain('Automation')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/nuxt/productsuite.spec.ts`
+Expected: FAIL — heading is `Product Suite`.
+
+- [ ] **Step 3: Rename the heading and drop the dead pills**
+
+In `app/components/homepage/ProductSuite.vue`, change the `<h2>` text from `Product Suite` to `What XeliAI does`.
+
+Then delete the entire `<div class="flex flex-wrap gap-2 items-center bg-white dark:bg-slate-900 p-1.5 rounded-xl ...">` block containing the `All`, `Support` and `Automation` buttons. They have no click handlers and filter nothing.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run test/nuxt/productsuite.spec.ts`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/homepage/ProductSuite.vue test/nuxt/productsuite.spec.ts
+git commit -m "refactor(home): rename Product Suite to What XeliAI does
+
+These cards describe capabilities inside XeliAI, not sibling products.
+Now that the nav has a Products menu meaning Trivia, Labs and the Blog,
+the old heading made the word mean two things on one page.
+
+Also removes the All, Support and Automation filter pills, which were
+plain buttons with no click handler that filtered nothing."
+```
+
+---
+
+## Task 8: The landing-page ecosystem strip
+
+**Files:**
+- Create: `app/components/homepage/EcosystemStrip.vue`
+- Modify: `app/pages/index.vue`
+- Test: `test/nuxt/ecosystemstrip.spec.ts`
+
+**Interfaces:**
+- Consumes: `useEcosystem()` from Task 1.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/nuxt/ecosystemstrip.spec.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import EcosystemStrip from '~/components/homepage/EcosystemStrip.vue'
+
+describe('EcosystemStrip', () => {
+  it('shows the three sibling products and not XeliAI itself', async () => {
+    const w = await mountSuspended(EcosystemStrip)
+    const cards = w.findAll('[data-ecosystem-card]')
+    expect(cards).toHaveLength(3)
+    expect(w.text()).toContain('XeliAI Trivia')
+    expect(w.text()).toContain('XeliAI Labs')
+    expect(w.text()).toContain('XeliAI Blog')
+  })
+
+  it('renders each tagline', async () => {
+    const w = await mountSuspended(EcosystemStrip)
+    expect(w.text()).toContain('Turn any study material into adaptive practice')
+  })
+
+  it('opens every card in a new tab safely', async () => {
+    const w = await mountSuspended(EcosystemStrip)
+    for (const card of w.findAll('[data-ecosystem-card]')) {
+      expect(card.attributes('target')).toBe('_blank')
+      expect(card.attributes('rel')).toBe('noopener noreferrer')
+    }
+  })
+
+  it('uses no em dashes', async () => {
+    const w = await mountSuspended(EcosystemStrip)
+    expect(w.text()).not.toContain('—')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/nuxt/ecosystemstrip.spec.ts`
+Expected: FAIL with `Failed to resolve import "~/components/homepage/EcosystemStrip.vue"`.
+
+- [ ] **Step 3: Write the component**
+
+Create `app/components/homepage/EcosystemStrip.vue`:
+
+```vue
+<!-- components/homepage/EcosystemStrip.vue -->
+<script setup>
+import { ArrowUpRight } from 'lucide-vue-next'
+import { useEcosystem } from '~/composables/useEcosystem'
+
+const { products } = useEcosystem()
+
+// The sibling apps only. XeliAI is the site you are already on.
+const siblings = products.filter(p => p.external)
+</script>
+
+<template>
+  <section class="py-20 bg-white dark:bg-slate-900 transition-colors duration-300">
+    <div class="max-w-7xl mx-auto px-6 lg:px-8">
+      <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white">
+        More from XeliAI
+      </h2>
+      <p class="mt-2 text-gray-500 dark:text-gray-400 text-lg">
+        One family of products. Pick the one you need.
+      </p>
+
+      <div class="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <a
+          v-for="product in siblings"
+          :key="product.id"
+          data-ecosystem-card
+          :href="product.href"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-6 rounded-2xl border border-gray-200 dark:border-slate-800 bg-gray-50 dark:bg-slate-950 hover:border-purple-400 dark:hover:border-purple-500 hover:-translate-y-1 transition-all duration-300"
+        >
+          <div class="flex items-start justify-between gap-3">
+            <h3 class="text-lg font-bold text-gray-900 dark:text-white">{{ product.name }}</h3>
+            <ArrowUpRight
+              class="w-5 h-5 text-gray-400 group-hover:text-purple-500 transition-colors"
+              aria-hidden="true"
+            />
+          </div>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+            {{ product.tagline }}
+          </p>
+        </a>
+      </div>
+    </div>
+  </section>
+</template>
+```
+
+- [ ] **Step 4: Mount it on the landing page**
+
+In `app/pages/index.vue`, add the import alongside the others:
+
+```js
+import EcosystemStrip from '../components/homepage/EcosystemStrip.vue'
+```
+
+and place it directly after `<ProductSuite />` in the template:
+
+```vue
+      <ProductSuite />
+      <EcosystemStrip />
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run test/nuxt/ecosystemstrip.spec.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 6: Run the full suite and build**
+
+Run: `npx vitest run`
+Expected: PASS, 43 tests across 8 files.
+
+Run: `npx nuxt build`
+Expected: build succeeds.
+
+- [ ] **Step 7: Retire navLinks**
+
+Confirm nothing imports it:
+
+Run: `npx vitest run` after deleting the `navLinks` export from `app/utils/data.js`.
+If the build and suite both pass, the removal is safe. If anything breaks, restore it and note which file still depends on it.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/components/homepage/EcosystemStrip.vue app/pages/index.vue app/utils/data.js test/nuxt/ecosystemstrip.spec.ts
+git commit -m "feat(home): add the ecosystem strip to the landing page
+
+The nav gets people to the other products; this makes them discoverable
+to a visitor who only scrolls. Built from the same registry, so adding a
+product to the family surfaces it here automatically.
+
+Retires navLinks, whose last consumer went away with the new nav."
+```
+
+---
+
+## Verification
+
+Before calling this done:
+
+- [ ] `npx vitest run` passes, 43 tests, 8 files.
+- [ ] `npx nuxt build` succeeds.
+- [ ] `npx nuxt dev`, then by hand at `http://localhost:3000`:
+  - [ ] each of Products, Business, Company and Log in opens, and opening one closes the others
+  - [ ] Escape closes the open menu and focus returns to its trigger
+  - [ ] Tab and the arrow keys move through menu items
+  - [ ] clicking outside closes the open menu
+  - [ ] Trivia, Labs and Blog links open the right sites in new tabs
+  - [ ] at mobile width, the drawer accordions expand and Tab stays inside the drawer
+  - [ ] the footer shows four columns and `Powered by LiteSigma` as plain text
+  - [ ] no `/features` link anywhere
+  - [ ] both light and dark mode look right
+- [ ] Ask before pushing.
+
+## Known gaps to report at the end
+
+1. `litesigma.com` does not resolve. The credit is plain text until it does.
+2. `Log in → Labs` goes to the Labs home page, not a login form, because Labs has no working auth.
+3. `NUXT_PUBLIC_TRIVIA_URL`, `NUXT_PUBLIC_LABS_URL` and `NUXT_PUBLIC_BLOG_URL` need setting per branch in Amplify. Defaults point at production, so an unset staging branch links visitors into production.
+4. Taglines are placeholder marketing copy and want an owner review before this reaches `main`.

--- a/docs/superpowers/specs/2026-08-12-ecosystem-nav-shell-design.md
+++ b/docs/superpowers/specs/2026-08-12-ecosystem-nav-shell-design.md
@@ -93,7 +93,7 @@ export const products = [
   {
     id: 'trivia',
     name: 'XeliAI Trivia',
-    tagline: 'Adaptive exam prep — JAMB, WAEC and more',
+    tagline: 'Turn any study material into adaptive practice',
     href: TRIVIA_URL,
     loginHref: `${TRIVIA_URL}/auth/login`,
     external: true,

--- a/docs/superpowers/specs/2026-08-12-ecosystem-nav-shell-design.md
+++ b/docs/superpowers/specs/2026-08-12-ecosystem-nav-shell-design.md
@@ -16,7 +16,9 @@ Three explicit requirements from the request:
 
 1. A Products menu on the landing page listing the other apps, reachable from `xeliai.com`.
 2. A login control offering "log in to Trivia / XeliAI / Labs".
-3. `Powered by LiteSigma` in the footer — **the only place LiteSigma appears anywhere on the site.**
+3. `Powered by LiteSigma` in the footer, linking to the company site, plus a LiteSigma entry in the
+   Company menu. (Amended 2026-08-14 by the owner; the original brief said the footer credit was the
+   only place LiteSigma appears.)
 
 ## 2. What the family actually is
 
@@ -26,7 +28,7 @@ Three explicit requirements from the request:
 | XeliAI Trivia | `trivia.xeliai.com` | FastAPI + Postgres · Nuxt 3 | Own JWT + Google OAuth + guest accounts |
 | XeliAI Labs | `labs.xeliai.com` | Nuxt 4, mock data | **None.** `composables/useAuth.js` is empty, `middleware/auth.js` is a no-op, `pages/auth/Login.vue:222` calls `navigateTo("/dashboard")` |
 | XeliAI Blog | `blog.xeliai.com` | — | No login |
-| LiteSigma | `litesigma.com` | — | Parent company. Labs' git remote is `LiteSigma-Tech/xeliai_lab` |
+| LiteSigma | `www.litesigma.com.ng` | — | Parent company. Labs' git remote is `LiteSigma-Tech/xeliai_lab` |
 
 All four XeliAI domains returned HTTP 200 on 2026-08-12. `litesigma.com` did **not** resolve
 (SERVFAIL against 8.8.8.8; `xeliai.com` resolved from the same query, so this is a real result and
@@ -64,7 +66,7 @@ already on.
 | D4 | **Menus link only to pages that exist.** | No `coming soon` stubs, no 404s. Items get added as pages are written. |
 | D5 | **Registry-driven, hand-rolled Tailwind.** | The product list appears in four places (desktop nav, mobile drawer, login menu, footer). Nuxt UI is installed but used in exactly one dashboard file, so its design system would clash on the most visible page of the site. |
 | D6 | **Labs links to its home page, not its login.** | Labs has no working auth. Linking "Log in → Labs" would send users to a form that authenticates nobody. Revisit when Labs has real auth. |
-| D7 | **`Powered by LiteSigma` is plain text, not a link.** | `litesigma.com` does not resolve. The URL stays in the registry so enabling the link later is a one-line change. |
+| D7 | ~~`Powered by LiteSigma` is plain text, not a link.~~ **SUPERSEDED 2026-08-14:** the credit links to `https://www.litesigma.com.ng/`, and LiteSigma also appears in the Company menu. | The original ruling assumed `litesigma.com`, which does not resolve. The owner supplied the real domain, a `.com.ng`, which is live. `linkEnabled` is now `true`. |
 
 ### Non-goals
 
@@ -124,17 +126,19 @@ export const menus = {
     { label: 'Get started',      to: '/get-started' },
   ],
   company: [
-    { label: 'About',   to: '/about' },
-    { label: 'Contact', to: '/contact' },
-    { label: 'Terms',   to: '/terms' },
-    { label: 'Privacy', to: '/privacy' },
+    { label: 'About',     to: '/about' },
+    { label: 'Contact',   to: '/contact' },
+    { label: parentCompany.name, to: parentCompany.url, external: true },
+    { label: 'Terms',     to: '/terms' },
+    { label: 'Privacy',   to: '/privacy' },
   ],
 }
 
+// Declared BEFORE menus so the Company entry reuses this exact URL.
 export const parentCompany = {
-  name: 'LiteSigma',
-  url: 'https://litesigma.com',
-  linkEnabled: false,             // D7 — domain does not resolve
+  name: 'LiteSigma Tech',
+  url: 'https://www.litesigma.com.ng/',
+  linkEnabled: true,
 }
 ```
 
@@ -251,11 +255,14 @@ no help centre. Its real links (Contact, Privacy, Terms) survive under Company a
 Legal bar:
 
 ```
-© 2026 XeliAI · All rights reserved      Powered by LiteSigma      Terms · Privacy
+© 2026 XeliAI · All rights reserved      Powered by LiteSigma Tech      Terms · Privacy
 ```
 
-`Powered by LiteSigma` renders as plain text while `parentCompany.linkEnabled === false` (D7). This
-is the only occurrence of LiteSigma on the site; it is simultaneously **removed** from the old
+`Powered by LiteSigma Tech` links to `parentCompany.url` while `linkEnabled === true` (D7,
+superseded). The name renders from `parentCompany.name`, and the Company menu entry reuses that same
+constant, so the two can never disagree.
+LiteSigma now appears twice in the footer, once in the Company column and once in the credit, and
+once more in the Company nav menu. It is simultaneously **removed** from the old
 Ecosystem column, where it currently links to a domain that does not resolve.
 
 ## 8. Landing page
@@ -331,7 +338,8 @@ These are all in code the new work directly touches. Each is a real, verified de
 
 ## 13. Open items requiring human action
 
-1. **`litesigma.com` does not resolve.** Until it does, `Powered by LiteSigma` is plain text. Flip
+1. ~~**`litesigma.com` does not resolve.**~~ **RESOLVED 2026-08-14:** the real domain is
+   `https://www.litesigma.com.ng/`, which is live. The credit is now a link. Superseded text: Flip
    `parentCompany.linkEnabled` to `true` when the domain is live.
 2. **Labs has no auth.** `Log in → Labs` points at the Labs home page (D6). Repoint at
    `labs.xeliai.com/auth/Login` once Labs has real authentication.

--- a/docs/superpowers/specs/2026-08-12-ecosystem-nav-shell-design.md
+++ b/docs/superpowers/specs/2026-08-12-ecosystem-nav-shell-design.md
@@ -1,0 +1,348 @@
+# XeliAI Ecosystem Nav Shell — Design
+
+**Date:** 2026-08-12
+**Repo:** `akaili_ai_frontend` (branch `dev`)
+**Status:** Approved design, not yet implemented
+
+---
+
+## 1. Goal
+
+Turn the XeliAI landing page into the hub for the whole product family, following the pattern
+OpenAI uses: a Products menu that lists the sibling apps, Business and Company menus, a **Log in
+dropdown that routes to each product's own login**, and a footer that credits the parent company.
+
+Three explicit requirements from the request:
+
+1. A Products menu on the landing page listing the other apps, reachable from `xeliai.com`.
+2. A login control offering "log in to Trivia / XeliAI / Labs".
+3. `Powered by LiteSigma` in the footer — **the only place LiteSigma appears anywhere on the site.**
+
+## 2. What the family actually is
+
+| Product | Domain | Stack | Auth today |
+|---|---|---|---|
+| XeliAI | `xeliai.com` | Laravel 12 + MongoDB · Nuxt 4 | Sanctum bearer token |
+| XeliAI Trivia | `trivia.xeliai.com` | FastAPI + Postgres · Nuxt 3 | Own JWT + Google OAuth + guest accounts |
+| XeliAI Labs | `labs.xeliai.com` | Nuxt 4, mock data | **None.** `composables/useAuth.js` is empty, `middleware/auth.js` is a no-op, `pages/auth/Login.vue:222` calls `navigateTo("/dashboard")` |
+| XeliAI Blog | `blog.xeliai.com` | — | No login |
+| LiteSigma | `litesigma.com` | — | Parent company. Labs' git remote is `LiteSigma-Tech/xeliai_lab` |
+
+All four XeliAI domains returned HTTP 200 on 2026-08-12. `litesigma.com` did **not** resolve
+(SERVFAIL against 8.8.8.8; `xeliai.com` resolved from the same query, so this is a real result and
+not a local network fault).
+
+## 3. Reference: what OpenAI actually does
+
+Verified by parsing the live `openai.com` HTML on 2026-08-12, not from memory.
+
+- Top nav is five items: **Research, Business, Developers, Company, Foundation**. Mega-menu contents
+  are client-rendered and not present in the static HTML.
+- On the right: a **`Log in` dropdown** (`<button aria-haspopup="menu" aria-expanded="false">`),
+  next to a solid **`Try ChatGPT`** CTA linking out to `chatgpt.com` in a new window.
+- Footer has eleven column headings: Research, Latest Advancements, Safety, Products, API Platform,
+  Business, Developers, Company, Support, More, Terms & Policies.
+- The **Products** column links to `chatgpt.com`, `chatgpt.com/business`, `/codex/`. The **API
+  Platform** column's second link is literally `API Log In → platform.openai.com/login`.
+
+**The load-bearing insight:** every product lives on its own domain with its own login. The
+marketing site is a hub that *routes* to them. The login dropdown exists precisely *because* there
+is no single sign-on — it is a disambiguator, not an auth system.
+
+**Where XeliAI differs:** OpenAI's split is clean — `openai.com` is corporate, `chatgpt.com` is the
+product. `xeliai.com` is **both** the company site and the chatbot's own product site. Consequence:
+`Products → XeliAI` must point at `/products`, not `/`, or the menu item reloads the page you are
+already on.
+
+## 4. Locked decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Login links out per product. No SSO.** | Three unrelated auth systems (Sanctum/Mongo, JWT/Postgres, none). SSO would mean building an identity provider and migrating Trivia's live paying users. This is what OpenAI does. Pure frontend, zero backend work. |
+| D2 | **"Product" means a sibling app only.** | Avoids the word meaning two things on one page. The existing on-page `ProductSuite` section (Bot, Business Assistant, Automation Tools) describes features *inside* XeliAI and is renamed. |
+| D3 | **Scope is the XeliAI landing shell only.** | Trivia is in production with paying users; Labs is on a different Nuxt major. Build it once here, prove it, port later as a file copy. |
+| D4 | **Menus link only to pages that exist.** | No `coming soon` stubs, no 404s. Items get added as pages are written. |
+| D5 | **Registry-driven, hand-rolled Tailwind.** | The product list appears in four places (desktop nav, mobile drawer, login menu, footer). Nuxt UI is installed but used in exactly one dashboard file, so its design system would clash on the most visible page of the site. |
+| D6 | **Labs links to its home page, not its login.** | Labs has no working auth. Linking "Log in → Labs" would send users to a form that authenticates nobody. Revisit when Labs has real auth. |
+| D7 | **`Powered by LiteSigma` is plain text, not a link.** | `litesigma.com` does not resolve. The URL stays in the registry so enabling the link later is a one-line change. |
+
+### Non-goals
+
+- No single sign-on, no shared session, no cross-domain auth of any kind.
+- No changes to Trivia or Labs.
+- No new marketing pages (Solutions, Careers, Customer Stories).
+- No backend changes. Nothing in `lite_sigma_chat_agent_backend/` is touched.
+- No changes to the existing dashboard, auth, onboarding, billing or checkout flows.
+
+## 5. Architecture
+
+### 5.1 The registry — `app/utils/ecosystem.js`
+
+Single source of truth. Every consumer reads from it; none hardcodes a product.
+
+```js
+export const products = [
+  {
+    id: 'xeliai',
+    name: 'XeliAI',
+    tagline: 'AI chatbot trained on your business data',
+    href: '/products',
+    loginHref: '/login',
+    external: false,
+  },
+  {
+    id: 'trivia',
+    name: 'XeliAI Trivia',
+    tagline: 'Adaptive exam prep — JAMB, WAEC and more',
+    href: TRIVIA_URL,
+    loginHref: `${TRIVIA_URL}/auth/login`,
+    external: true,
+  },
+  {
+    id: 'labs',
+    name: 'XeliAI Labs',
+    tagline: 'Courses, mentorship and talent',
+    href: LABS_URL,
+    loginHref: LABS_URL,          // D6 — Labs has no working auth
+    external: true,
+  },
+  {
+    id: 'blog',
+    name: 'XeliAI Blog',
+    tagline: 'Product news and writing',
+    href: BLOG_URL,
+    loginHref: null,              // no login — excluded from the login menu
+    external: true,
+  },
+]
+
+export const menus = {
+  business: [
+    { label: 'Pricing',          to: '/pricing' },
+    { label: 'Referral Program', to: '/referrals' },
+    { label: 'Talk to sales',    to: '/contact' },
+    { label: 'Get started',      to: '/get-started' },
+  ],
+  company: [
+    { label: 'About',   to: '/about' },
+    { label: 'Contact', to: '/contact' },
+    { label: 'Terms',   to: '/terms' },
+    { label: 'Privacy', to: '/privacy' },
+  ],
+}
+
+export const parentCompany = {
+  name: 'LiteSigma',
+  url: 'https://litesigma.com',
+  linkEnabled: false,             // D7 — domain does not resolve
+}
+```
+
+`loginHref: null` is meaningful, not incidental: it is the single field that keeps the Blog out of
+the login dropdown while keeping it in the Products menu and footer.
+
+### 5.2 URLs come from `runtimeConfig.public`
+
+Product URLs are **not** hardcoded strings. `nuxt.config.ts` already sources `apiBase` this way, and
+commit `ce9e719` just moved runtime config onto public env vars.
+
+```ts
+runtimeConfig: {
+  public: {
+    triviaUrl: process.env.NUXT_PUBLIC_TRIVIA_URL || 'https://trivia.xeliai.com',
+    labsUrl:   process.env.NUXT_PUBLIC_LABS_URL   || 'https://labs.xeliai.com',
+    blogUrl:   process.env.NUXT_PUBLIC_BLOG_URL   || 'https://blog.xeliai.com',
+  }
+}
+```
+
+Without this, a `dev.xeliai.com` build links visitors straight into production.
+
+Because `runtimeConfig` is only readable inside a Nuxt context, the registry exports a
+`useEcosystem()` composable that resolves the URLs at call time. The raw arrays stay exported for
+unit tests.
+
+## 6. Navbar
+
+### 6.1 Desktop, logged out
+
+```
+[logo]   Products ▾   Business ▾   Company ▾   Pricing        🌓   [ Log in ▾ ]   [ Get Started ]
+```
+
+Seven flat links collapse into three menus plus Pricing. **Pricing stays top-level deliberately** —
+it is the highest-intent page on the site and burying it in a dropdown costs signups.
+
+| Products ▾ | Business ▾ | Company ▾ |
+|---|---|---|
+| XeliAI | Pricing | About |
+| XeliAI Trivia ↗ | Referral Program | Contact |
+| XeliAI Labs ↗ | Talk to sales | Terms |
+| XeliAI Blog ↗ | Get started | Privacy |
+
+Products entries render their `tagline` as a second line. Business and Company are plain link lists.
+
+Two deliberate duplications: **Pricing** appears both top-level and under Business, and the **Blog**
+sits under Products rather than Company. The first is a conversion decision; the second keeps the
+Blog in exactly one menu, since it is registered as a product. OpenAI duplicates similarly (`Docs`
+appears under both API Platform and Developers).
+
+### 6.2 The login dropdown
+
+```
+Log in ▾
+  XeliAI            → /login
+  XeliAI Trivia ↗   → trivia.xeliai.com/auth/login
+  XeliAI Labs   ↗   → labs.xeliai.com
+```
+
+Generated by filtering `products` on `loginHref !== null`.
+
+**Hard constraint:** this menu must never imply knowledge of a Trivia or Labs session. `authStore`
+holds a XeliAI Sanctum token and nothing else — different domains, different cookies, three
+unrelated auth systems. Entries are plainly labelled links with an external-link affordance. No
+"signed in as…", no session indicator, no per-product state.
+
+### 6.3 Authenticated state
+
+The existing profile menu is preserved exactly as-is — same trigger, same `Dashboard` and `Logout`
+items, same handlers. It gains a divider and the Trivia/Labs links beneath. Same honesty constraint
+as 6.2 applies.
+
+### 6.4 Behaviour and accessibility
+
+Menus open on **click**, not hover. Hover menus are unusable on touch and hostile to keyboard users,
+and click is what OpenAI uses for its own Log in control.
+
+- trigger: `aria-haspopup="menu"`, `aria-expanded` reflecting state
+- panel: `role="menu"`, items `role="menuitem"`
+- `Escape` closes and returns focus to the trigger
+- `ArrowDown` / `ArrowUp` move between items, `Home` / `End` jump to ends
+- click outside closes
+- route change closes
+- only one menu open at a time
+
+All four dropdowns share a `useDropdown()` composable holding this logic.
+
+### 6.5 Mobile drawer
+
+The existing purple slide-in drawer is kept. The three menus become collapsible accordions; the
+login links sit above the `Get Started` button at the bottom. A focus trap is added (see §9).
+
+## 7. Footer
+
+Columns, all generated from the registry where applicable:
+
+| Products | Business | Company | Legal |
+|---|---|---|---|
+| XeliAI | Pricing | About | Terms |
+| XeliAI Trivia ↗ | Referral Program | Contact | Privacy |
+| XeliAI Labs ↗ | Talk to sales | | |
+| XeliAI Blog ↗ | Get started | | |
+
+The footer columns mirror the nav menus exactly — same registry, same `menus` object — so the two
+cannot drift.
+
+Two changes from the current footer beyond B1/B2. The `Xeliai Ecosystem` column is **removed**; the
+Products column now does that job formally, from shared data. And the `Support` column is
+**retired**: its `Help Center` link pointed at `/contact`, which is a mislabel under D4 — there is
+no help centre. Its real links (Contact, Privacy, Terms) survive under Company and Legal.
+
+Legal bar:
+
+```
+© 2026 XeliAI · All rights reserved      Powered by LiteSigma      Terms · Privacy
+```
+
+`Powered by LiteSigma` renders as plain text while `parentCompany.linkEnabled === false` (D7). This
+is the only occurrence of LiteSigma on the site; it is simultaneously **removed** from the old
+Ecosystem column, where it currently links to a domain that does not resolve.
+
+## 8. Landing page
+
+- `ProductSuite.vue` heading: **"Product Suite" → "What XeliAI does"** (D2). The cards themselves are
+  unchanged.
+- New `EcosystemStrip.vue` below it: three compact cards for Trivia, Labs and Blog, from the
+  registry. The nav gets people to the other products; this makes them discoverable to a visitor who
+  only scrolls.
+
+## 9. Pre-existing defects fixed along the way
+
+These are all in code the new work directly touches. Each is a real, verified defect on `dev` today.
+
+| # | Defect | Fix |
+|---|---|---|
+| B1 | `Footer.vue` — an orphaned `<div class="space-y-5">` "Product" block sits between `.brand-col` and `.nav-columns`. It is a flex child of `.footer-top`, not a grid cell, so it does not align with the other columns, and it is styled with raw Tailwind while every neighbour uses scoped CSS classes. | Delete it. Its links already exist elsewhere. |
+| B2 | That block links to `/features`, which has no page — a 404. | Removed with B1. Regression-tested. |
+| B3 | `MainNavbar.vue:35` closes menus via `document.querySelector('[data-profile-menu]')` — one hardcoded selector. With four dropdowns it closes the wrong menu. | Per-instance refs inside `useDropdown()`. |
+| B4 | The mobile drawer sets `aria-modal="true"` but has no focus trap, so keyboard focus walks out of it into the page behind. | Add a focus trap. |
+| B5 | `navLinks` carries a `more` field that renders a `ChevronDown`, but `more` is `''` on every entry and no dropdown was ever built — a dead affordance shipped today. | Superseded by real dropdowns. |
+| B6 | `ProductSuite.vue` — the `All / Support / Automation` filter pills are plain `<button>`s with no click handler. | Remove them. |
+
+## 10. Error handling and edge cases
+
+- **External links** always carry `target="_blank"` and `rel="noopener noreferrer"`. Driven by the
+  registry's `external` flag, so it cannot be forgotten on a new entry.
+- **A product domain being down is not handled.** These are plain anchors; no health checks, no
+  liveness probes. A dead sibling domain degrades to a failed navigation, which is correct and
+  costs nothing.
+- **`loginHref: null`** removes a product from the login menu only. It stays in Products and the
+  footer.
+- **`linkEnabled: false`** renders the parent company as text. No anchor, no hover state.
+- **SSR:** the registry is pure data plus `runtimeConfig` reads, safe on both server and client. No
+  `window` access at module scope.
+- **No impact on authenticated flows.** `authStore`, middleware, the dashboard layout, checkout and
+  payment are untouched.
+
+## 11. Testing
+
+`npm run test` currently runs **zero** tests — `test/nuxt/` is empty. These are the repo's first.
+
+| Test | Asserts |
+|---|---|
+| registry shape | every product has `id`, `name`, `tagline`, `href`, `external`; `loginHref === null` only for `blog` |
+| login menu | renders exactly three entries; never contains the Blog |
+| products menu | renders all four products with taglines |
+| external links | every `external: true` link has `target="_blank"` and `rel="noopener noreferrer"` |
+| dropdown a11y | `aria-expanded` flips on open/close; `Escape` closes and restores focus to the trigger |
+| single-open | opening one dropdown closes any other |
+| footer regression | the rendered footer contains no `/features` link (guards B2) |
+| parent company | renders as text, not an anchor, while `linkEnabled` is false |
+
+## 12. Files changed
+
+**New**
+
+- `app/utils/ecosystem.js` — the registry
+- `app/composables/useEcosystem.js` — resolves registry URLs from `runtimeConfig`
+- `app/composables/useDropdown.js` — shared open/close, keyboard and click-outside logic
+- `app/components/homepage/NavDropdown.vue` — one menu, used four times
+- `app/components/homepage/EcosystemStrip.vue` — the landing-page family section
+- `test/nuxt/ecosystem.spec.ts`, `test/nuxt/navbar.spec.ts`, `test/nuxt/footer.spec.ts`
+
+**Modified**
+
+- `nuxt.config.ts` — three `runtimeConfig.public` URL entries
+- `app/components/homepage/MainNavbar.vue` — menus, login dropdown, mobile accordions, B3, B4, B5
+- `app/components/homepage/Footer.vue` — columns from registry, legal bar, B1, B2
+- `app/components/homepage/ProductSuite.vue` — heading rename, B6
+- `app/pages/index.vue` — mount `EcosystemStrip`
+- `app/utils/data.js` — retire `navLinks` once nothing reads it
+
+## 13. Open items requiring human action
+
+1. **`litesigma.com` does not resolve.** Until it does, `Powered by LiteSigma` is plain text. Flip
+   `parentCompany.linkEnabled` to `true` when the domain is live.
+2. **Labs has no auth.** `Log in → Labs` points at the Labs home page (D6). Repoint at
+   `labs.xeliai.com/auth/Login` once Labs has real authentication.
+3. **Amplify env vars.** `NUXT_PUBLIC_TRIVIA_URL`, `NUXT_PUBLIC_LABS_URL`, `NUXT_PUBLIC_BLOG_URL`
+   should be set per branch. Defaults point at production, so an unset staging branch will link
+   visitors into production.
+4. **Product taglines are placeholders** written from reading each codebase. They are marketing copy
+   and should be reviewed before this goes to `main`.
+
+## 14. Relationship to `CLAUDE_CODE_EXECUTION_SPEC.md`
+
+This work is **not** in that spec, which covers referrals, geo-pricing, the ledger and the admin
+panel. It is a separate directive and does not alter, reorder or block any phase there. It touches
+no backend code, no money path, and no existing API contract.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -87,6 +87,10 @@ export default defineNuxtConfig({
 
       stripePublishableKey: process.env.STRIPE_KEY,
       paystackPublicKey: process.env.PAYSTACK_PUBLIC_KEY,
+
+      triviaUrl: process.env.NUXT_PUBLIC_TRIVIA_URL || "https://trivia.xeliai.com",
+      labsUrl: process.env.NUXT_PUBLIC_LABS_URL || "https://labs.xeliai.com",
+      blogUrl: process.env.NUXT_PUBLIC_BLOG_URL || "https://blog.xeliai.com",
     },
   },
 

--- a/test/nuxt/dropdown.spec.ts
+++ b/test/nuxt/dropdown.spec.ts
@@ -1,7 +1,19 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { defineComponent, h } from 'vue'
 import { useDropdown } from '~/composables/useDropdown'
+
+// Component that resets the shared useState state by calling useState
+// and setting it to null. Must be mounted before each test to ensure
+// clean state, then immediately unmounted.
+const StateResetter = defineComponent({
+  setup() {
+    const openId = useState('nav:openDropdown', () => null)
+    openId.value = null
+    return {}
+  },
+  template: '<div></div>',
+})
 
 // The returned object is flattened deliberately. Vue only unwraps refs
 // returned at the top level of setup, so `this.a.isOpen` would stay a
@@ -28,6 +40,14 @@ const Harness = defineComponent({
 })
 
 describe('useDropdown', () => {
+  beforeEach(async () => {
+    // Reset the shared useState state before each test by mounting and
+    // unmounting a component that explicitly sets it to null. This ensures
+    // each test starts with a clean state, even when tests are run in suite.
+    const resetter = await mountSuspended(StateResetter)
+    await resetter.unmount()
+  })
+
   it('starts closed', async () => {
     const w = await mountSuspended(Harness)
     expect(w.find('#pa').exists()).toBe(false)

--- a/test/nuxt/dropdown.spec.ts
+++ b/test/nuxt/dropdown.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineComponent, h } from 'vue'
+import { useDropdown } from '~/composables/useDropdown'
+
+// The returned object is flattened deliberately. Vue only unwraps refs
+// returned at the top level of setup, so `this.a.isOpen` would stay a
+// Ref and read as truthy forever.
+const Harness = defineComponent({
+  setup() {
+    const a = useDropdown('a')
+    const b = useDropdown('b')
+    return {
+      aOpen: a.isOpen,
+      bOpen: b.isOpen,
+      aToggle: a.toggle,
+      bToggle: b.toggle,
+    }
+  },
+  render() {
+    return h('div', [
+      h('button', { id: 'ta', onClick: () => this.aToggle() }, 'A'),
+      h('button', { id: 'tb', onClick: () => this.bToggle() }, 'B'),
+      this.aOpen ? h('div', { id: 'pa' }, 'panel a') : null,
+      this.bOpen ? h('div', { id: 'pb' }, 'panel b') : null,
+    ])
+  },
+})
+
+describe('useDropdown', () => {
+  it('starts closed', async () => {
+    const w = await mountSuspended(Harness)
+    expect(w.find('#pa').exists()).toBe(false)
+  })
+
+  it('opens on toggle', async () => {
+    const w = await mountSuspended(Harness)
+    await w.find('#ta').trigger('click')
+    expect(w.find('#pa').exists()).toBe(true)
+  })
+
+  it('closes on a second toggle', async () => {
+    const w = await mountSuspended(Harness)
+    await w.find('#ta').trigger('click')
+    await w.find('#ta').trigger('click')
+    expect(w.find('#pa').exists()).toBe(false)
+  })
+
+  it('opening one closes the other', async () => {
+    const w = await mountSuspended(Harness)
+    await w.find('#ta').trigger('click')
+    await w.find('#tb').trigger('click')
+    expect(w.find('#pa').exists()).toBe(false)
+    expect(w.find('#pb').exists()).toBe(true)
+  })
+
+  it('closes on Escape', async () => {
+    const w = await mountSuspended(Harness)
+    await w.find('#ta').trigger('click')
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await w.vm.$nextTick()
+    expect(w.find('#pa').exists()).toBe(false)
+  })
+})

--- a/test/nuxt/ecolink.spec.ts
+++ b/test/nuxt/ecolink.spec.ts
@@ -34,4 +34,47 @@ describe('EcoLink', () => {
     })
     expect(w.text()).toContain('Slot content here')
   })
+
+  it('renders the external-link glyph and hidden text by default', async () => {
+    const w = await mountSuspended(EcoLink, {
+      props: { item: { label: 'External', to: 'https://example.com', external: true } },
+      slots: { default: () => 'External' },
+    })
+    expect(w.find('svg').exists()).toBe(true)
+    expect(w.text()).toContain('opens in a new tab')
+  })
+
+  // A caller with its own designed external-link treatment (the
+  // ecosystem strip's large corner arrow) can suppress EcoLink's own
+  // glyph so a single link does not render two arrows. The
+  // visually-hidden text must survive the opt-out: it is the
+  // accessibility contract, not a decoration, so screen-reader users
+  // still get the context-switch warning even with the glyph hidden.
+  it('suppresses only the visual glyph when show-external-icon is false, keeping the hidden text', async () => {
+    const w = await mountSuspended(EcoLink, {
+      props: {
+        item: { label: 'External', to: 'https://example.com', external: true },
+        showExternalIcon: false,
+      },
+      slots: { default: () => 'External' },
+    })
+    expect(w.find('svg').exists()).toBe(false)
+    expect(w.text()).toContain('opens in a new tab')
+    // Still a fully-formed external link otherwise.
+    const a = w.find('a')
+    expect(a.attributes('target')).toBe('_blank')
+    expect(a.attributes('rel')).toBe('noopener noreferrer')
+  })
+
+  it('does not add a glyph or hidden text to internal links regardless of show-external-icon', async () => {
+    const w = await mountSuspended(EcoLink, {
+      props: {
+        item: { label: 'Internal', to: '/pricing' },
+        showExternalIcon: false,
+      },
+      slots: { default: () => 'Internal' },
+    })
+    expect(w.find('svg').exists()).toBe(false)
+    expect(w.text()).not.toContain('opens in a new tab')
+  })
 })

--- a/test/nuxt/ecolink.spec.ts
+++ b/test/nuxt/ecolink.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import EcoLink from '~/components/homepage/EcoLink.vue'
+
+describe('EcoLink', () => {
+  it('renders an anchor with target and rel for external items', async () => {
+    const w = await mountSuspended(EcoLink, {
+      props: { item: { label: 'External', to: 'https://example.com', external: true } },
+      slots: { default: () => 'External' },
+    })
+    const a = w.find('a')
+    expect(a.exists()).toBe(true)
+    expect(a.attributes('href')).toBe('https://example.com')
+    expect(a.attributes('target')).toBe('_blank')
+    expect(a.attributes('rel')).toBe('noopener noreferrer')
+  })
+
+  it('renders a link with neither target nor rel for internal items', async () => {
+    const w = await mountSuspended(EcoLink, {
+      props: { item: { label: 'Internal', to: '/pricing' } },
+      slots: { default: () => 'Internal' },
+    })
+    const link = w.find('a')
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href')).toBe('/pricing')
+    expect(link.attributes('target')).toBeUndefined()
+    expect(link.attributes('rel')).toBeUndefined()
+  })
+
+  it('renders the default slot content', async () => {
+    const w = await mountSuspended(EcoLink, {
+      props: { item: { label: 'Internal', to: '/pricing' } },
+      slots: { default: () => 'Slot content here' },
+    })
+    expect(w.text()).toContain('Slot content here')
+  })
+})

--- a/test/nuxt/ecosystem.spec.ts
+++ b/test/nuxt/ecosystem.spec.ts
@@ -57,8 +57,18 @@ describe('ecosystem registry', () => {
     for (const to of internal) expect(realPages).toContain(to)
   })
 
-  it('keeps the LiteSigma link disabled while the domain is down', () => {
-    expect(parentCompany.name).toBe('LiteSigma')
-    expect(parentCompany.linkEnabled).toBe(false)
+  it('points LiteSigma at the live .com.ng domain, linked', () => {
+    expect(parentCompany.name).toBe('LiteSigma Tech')
+    // The .com does not resolve; the real site is the .com.ng.
+    expect(parentCompany.url).toBe('https://www.litesigma.com.ng/')
+    expect(parentCompany.linkEnabled).toBe(true)
+  })
+
+  it('lists LiteSigma in the Company menu as an external link', () => {
+    const liteSigma = menus.company.find(i => i.label === 'LiteSigma Tech')
+    expect(liteSigma).toBeDefined()
+    expect(liteSigma.external).toBe(true)
+    // Same URL as the footer credit, from the same constant.
+    expect(liteSigma.to).toBe(parentCompany.url)
   })
 })

--- a/test/nuxt/ecosystem.spec.ts
+++ b/test/nuxt/ecosystem.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { buildProducts, menus, parentCompany } from '~/utils/ecosystem'
+
+const urls = {
+  triviaUrl: 'https://trivia.example.com',
+  labsUrl: 'https://labs.example.com',
+  blogUrl: 'https://blog.example.com',
+}
+
+describe('ecosystem registry', () => {
+  it('returns the four products in order', () => {
+    expect(buildProducts(urls).map(p => p.id)).toEqual(['xeliai', 'trivia', 'labs', 'blog'])
+  })
+
+  it('gives every product the required fields', () => {
+    for (const p of buildProducts(urls)) {
+      expect(p.name).toBeTruthy()
+      expect(p.tagline).toBeTruthy()
+      expect(p.href).toBeTruthy()
+      expect(typeof p.external).toBe('boolean')
+    }
+  })
+
+  it('marks only the blog as having no login', () => {
+    const noLogin = buildProducts(urls).filter(p => p.loginHref === null)
+    expect(noLogin.map(p => p.id)).toEqual(['blog'])
+  })
+
+  it('points XeliAI at /products, not the site root', () => {
+    const xeliai = buildProducts(urls).find(p => p.id === 'xeliai')
+    expect(xeliai.href).toBe('/products')
+    expect(xeliai.external).toBe(false)
+  })
+
+  it('builds sibling URLs from the values it is given', () => {
+    const built = buildProducts(urls)
+    expect(built.find(p => p.id === 'trivia').loginHref).toBe('https://trivia.example.com/auth/login')
+    expect(built.find(p => p.id === 'labs').loginHref).toBe('https://labs.example.com')
+    expect(built.find(p => p.id === 'blog').href).toBe('https://blog.example.com')
+  })
+
+  it('uses no em dashes in any user-facing string', () => {
+    const copy = [
+      ...buildProducts(urls).flatMap(p => [p.name, p.tagline]),
+      ...menus.business.map(i => i.label),
+      ...menus.company.map(i => i.label),
+      parentCompany.name,
+    ]
+    for (const s of copy) expect(s).not.toContain('—')
+  })
+
+  it('links menus only to pages that exist', () => {
+    const internal = [...menus.business, ...menus.company]
+      .filter(i => !i.external)
+      .map(i => i.to)
+    const realPages = ['/pricing', '/referrals', '/contact', '/get-started', '/about', '/terms', '/privacy']
+    for (const to of internal) expect(realPages).toContain(to)
+  })
+
+  it('keeps the LiteSigma link disabled while the domain is down', () => {
+    expect(parentCompany.name).toBe('LiteSigma')
+    expect(parentCompany.linkEnabled).toBe(false)
+  })
+})

--- a/test/nuxt/ecosystemstrip.spec.ts
+++ b/test/nuxt/ecosystemstrip.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import EcosystemStrip from '~/components/homepage/EcosystemStrip.vue'
+
+describe('EcosystemStrip', () => {
+  it('shows the three sibling products and not XeliAI itself', async () => {
+    const w = await mountSuspended(EcosystemStrip)
+    const cards = w.findAll('[data-ecosystem-card]')
+    expect(cards).toHaveLength(3)
+    expect(w.text()).toContain('XeliAI Trivia')
+    expect(w.text()).toContain('XeliAI Labs')
+    expect(w.text()).toContain('XeliAI Blog')
+  })
+
+  it('renders each tagline', async () => {
+    const w = await mountSuspended(EcosystemStrip)
+    expect(w.text()).toContain('Turn any study material into adaptive practice')
+  })
+
+  it('opens every card in a new tab safely', async () => {
+    const w = await mountSuspended(EcosystemStrip)
+    for (const card of w.findAll('[data-ecosystem-card]')) {
+      expect(card.attributes('target')).toBe('_blank')
+      expect(card.attributes('rel')).toBe('noopener noreferrer')
+    }
+  })
+
+  it('uses no em dashes', async () => {
+    const w = await mountSuspended(EcosystemStrip)
+    expect(w.text()).not.toContain('—')
+  })
+})

--- a/test/nuxt/footer.spec.ts
+++ b/test/nuxt/footer.spec.ts
@@ -22,15 +22,32 @@ describe('Footer', () => {
     expect(text).toContain('XeliAI Blog')
   })
 
-  it('credits LiteSigma as plain text while the domain is down', async () => {
+  it('credits LiteSigma as a live link to the .com.ng site', async () => {
     const w = await mountSuspended(Footer)
-    expect(w.text()).toContain('Powered by LiteSigma')
-    expect(w.find('[data-parent-company]').element.tagName).not.toBe('A')
+    expect(w.text()).toContain('Powered by LiteSigma Tech')
+
+    const credit = w.find('[data-parent-company]')
+    expect(credit.element.tagName).toBe('A')
+    expect(credit.attributes('href')).toBe('https://www.litesigma.com.ng/')
+    // It leaves the site, so it must carry the same protections as any
+    // other external link.
+    expect(credit.attributes('target')).toBe('_blank')
+    expect(credit.attributes('rel')).toBe('noopener noreferrer')
   })
 
-  it('mentions LiteSigma exactly once', async () => {
+  it('shows LiteSigma in both the Company column and the credit', async () => {
     const w = await mountSuspended(Footer)
-    expect(w.text().match(/LiteSigma/g)).toHaveLength(1)
+    // Two deliberate occurrences: the Company column entry and the
+    // "Powered by" credit. Any other count means one of them was lost or
+    // something started rendering it a third time.
+    expect(w.text().match(/LiteSigma/g) ?? []).toHaveLength(2)
+
+    const companyLink = w
+      .findAll('a')
+      .find(a => a.attributes('href') === 'https://www.litesigma.com.ng/' && !a.attributes('data-parent-company'))
+    expect(companyLink).toBeDefined()
+    expect(companyLink.attributes('target')).toBe('_blank')
+    expect(companyLink.attributes('rel')).toBe('noopener noreferrer')
   })
 
   it('gives every external link target and rel', async () => {

--- a/test/nuxt/footer.spec.ts
+++ b/test/nuxt/footer.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import Footer from '~/components/homepage/Footer.vue'
+
+describe('Footer', () => {
+  it('does not link to the non-existent /features page', async () => {
+    const w = await mountSuspended(Footer)
+    expect(w.html()).not.toContain('/features')
+  })
+
+  it('renders the four column headings', async () => {
+    const w = await mountSuspended(Footer)
+    const headings = w.findAll('h3').map(h => h.text())
+    expect(headings).toEqual(['Products', 'Business', 'Company', 'Legal'])
+  })
+
+  it('lists every product in the Products column', async () => {
+    const w = await mountSuspended(Footer)
+    const text = w.text()
+    expect(text).toContain('XeliAI Trivia')
+    expect(text).toContain('XeliAI Labs')
+    expect(text).toContain('XeliAI Blog')
+  })
+
+  it('credits LiteSigma as plain text while the domain is down', async () => {
+    const w = await mountSuspended(Footer)
+    expect(w.text()).toContain('Powered by LiteSigma')
+    expect(w.find('[data-parent-company]').element.tagName).not.toBe('A')
+  })
+
+  it('mentions LiteSigma exactly once', async () => {
+    const w = await mountSuspended(Footer)
+    expect(w.text().match(/LiteSigma/g)).toHaveLength(1)
+  })
+
+  it('gives every external link target and rel', async () => {
+    const w = await mountSuspended(Footer)
+    for (const a of w.findAll('a[target="_blank"]')) {
+      expect(a.attributes('rel')).toBe('noopener noreferrer')
+    }
+  })
+
+  it('uses no em dashes', async () => {
+    const w = await mountSuspended(Footer)
+    expect(w.text()).not.toContain('—')
+  })
+})

--- a/test/nuxt/navbar-mobile.spec.ts
+++ b/test/nuxt/navbar-mobile.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import MainNavbar from '~/components/homepage/MainNavbar.vue'
+
+const mount = () => mountSuspended(MainNavbar, {
+  global: { stubs: { ThemeToggle: true } },
+})
+
+describe('MainNavbar mobile drawer', () => {
+  it('renders a section button per menu', async () => {
+    const w = await mount()
+    const sections = w.findAll('[data-drawer-section]').map(b => b.text())
+    expect(sections).toEqual(['Products', 'Business', 'Company'])
+  })
+
+  it('expands a section on click', async () => {
+    const w = await mount()
+    const products = w.findAll('[data-drawer-section]')[0]
+    expect(products.attributes('aria-expanded')).toBe('false')
+    await products.trigger('click')
+    expect(products.attributes('aria-expanded')).toBe('true')
+    expect(w.find('#drawer-panel-products').text()).toContain('XeliAI Trivia')
+  })
+
+  it('collapses the open section when another opens', async () => {
+    const w = await mount()
+    const [products, business] = w.findAll('[data-drawer-section]')
+    await products.trigger('click')
+    await business.trigger('click')
+    expect(products.attributes('aria-expanded')).toBe('false')
+    expect(business.attributes('aria-expanded')).toBe('true')
+  })
+
+  it('offers the logins in the drawer', async () => {
+    const w = await mount()
+    expect(w.find('[data-drawer-logins]').findAll('a')).toHaveLength(3)
+  })
+})

--- a/test/nuxt/navbar-mobile.spec.ts
+++ b/test/nuxt/navbar-mobile.spec.ts
@@ -6,6 +6,16 @@ const mount = () => mountSuspended(MainNavbar, {
   global: { stubs: { ThemeToggle: true } },
 })
 
+// document.activeElement only tracks real focus for elements connected to
+// the live document. mountSuspended does not attach its root to
+// document.body by default, so any test asserting on activeElement must
+// mount with attachTo and unmount afterwards to avoid leaking nodes
+// between tests.
+const mountAttached = () => mountSuspended(MainNavbar, {
+  global: { stubs: { ThemeToggle: true } },
+  attachTo: document.body,
+})
+
 describe('MainNavbar mobile drawer', () => {
   it('renders a section button per menu', async () => {
     const w = await mount()
@@ -34,5 +44,88 @@ describe('MainNavbar mobile drawer', () => {
   it('offers the logins in the drawer', async () => {
     const w = await mount()
     expect(w.find('[data-drawer-logins]').findAll('a')).toHaveLength(3)
+  })
+
+  describe('focus trap', () => {
+    const focusablesOf = (asideEl) => asideEl.querySelectorAll(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )
+
+    it('does nothing on Tab keydown while the drawer is closed', async () => {
+      const w = await mountAttached()
+      try {
+        const aside = w.find('aside')
+        const focusables = focusablesOf(aside.element)
+        const last = focusables[focusables.length - 1]
+
+        last.focus()
+        expect(document.activeElement).toBe(last)
+
+        const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true })
+        aside.element.dispatchEvent(event)
+
+        // The drawer was never opened, so the trap must be inert: no
+        // preventDefault, and focus must not have been redirected.
+        expect(event.defaultPrevented).toBe(false)
+        expect(document.activeElement).toBe(last)
+      } finally {
+        w.unmount()
+      }
+    })
+
+    it('wraps Tab from the last focusable element to the first when open', async () => {
+      const w = await mountAttached()
+      try {
+        await w.find('[aria-label="Open mobile menu"]').trigger('click')
+        const aside = w.find('aside')
+        const focusables = focusablesOf(aside.element)
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+
+        last.focus()
+        expect(document.activeElement).toBe(last)
+
+        const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true })
+        aside.element.dispatchEvent(event)
+
+        expect(event.defaultPrevented).toBe(true)
+        expect(document.activeElement).toBe(first)
+      } finally {
+        w.unmount()
+      }
+    })
+
+    it('wraps Shift+Tab from the first focusable element to the last when open', async () => {
+      const w = await mountAttached()
+      try {
+        await w.find('[aria-label="Open mobile menu"]').trigger('click')
+        const aside = w.find('aside')
+        const focusables = focusablesOf(aside.element)
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+
+        first.focus()
+        expect(document.activeElement).toBe(first)
+
+        const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true })
+        aside.element.dispatchEvent(event)
+
+        expect(event.defaultPrevented).toBe(true)
+        expect(document.activeElement).toBe(last)
+      } finally {
+        w.unmount()
+      }
+    })
+
+    it('closes the drawer on Escape', async () => {
+      const w = await mount()
+      await w.find('[aria-label="Open mobile menu"]').trigger('click')
+      const aside = w.find('aside')
+      expect(aside.classes()).toContain('translate-x-0')
+
+      await aside.trigger('keydown', { key: 'Escape' })
+
+      expect(aside.classes()).toContain('-translate-x-full')
+    })
   })
 })

--- a/test/nuxt/navbar.spec.ts
+++ b/test/nuxt/navbar.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineComponent } from 'vue'
+import MainNavbar from '~/components/homepage/MainNavbar.vue'
+
+// Component that resets the shared useState state by calling useState
+// and setting it to null. Must be mounted before each test to ensure
+// clean state, then immediately unmounted. See test/nuxt/dropdown.spec.ts.
+const StateResetter = defineComponent({
+  setup() {
+    const openId = useState('nav:openDropdown', () => null)
+    openId.value = null
+    return {}
+  },
+  template: '<div></div>',
+})
+
+// ThemeToggle reads colorMode.value, and @nuxtjs/color-mode does not
+// initialise in the test environment, so it must be stubbed or the
+// render throws.
+const mount = () => mountSuspended(MainNavbar, {
+  global: { stubs: { ThemeToggle: true } },
+})
+
+describe('MainNavbar', () => {
+  beforeEach(async () => {
+    const resetter = await mountSuspended(StateResetter)
+    await resetter.unmount()
+  })
+
+  it('renders the three menus and a flat Pricing link', async () => {
+    const w = await mount()
+    const triggers = w.findAll('[aria-haspopup="menu"]').map(b => b.text())
+    expect(triggers.some(t => t.includes('Products'))).toBe(true)
+    expect(triggers.some(t => t.includes('Business'))).toBe(true)
+    expect(triggers.some(t => t.includes('Company'))).toBe(true)
+    expect(w.html()).toContain('/pricing')
+  })
+
+  it('lists all four products in the Products menu', async () => {
+    const w = await mount()
+    const products = w.findAll('[aria-haspopup="menu"]').find(b => b.text().includes('Products'))
+    await products.trigger('click')
+    const text = w.find('[role="menu"]').text()
+    expect(text).toContain('XeliAI Trivia')
+    expect(text).toContain('XeliAI Labs')
+    expect(text).toContain('XeliAI Blog')
+  })
+
+  it('offers three logins and never the blog', async () => {
+    const w = await mount()
+    const login = w.findAll('[aria-haspopup="menu"]').find(b => b.text().includes('Log in'))
+    await login.trigger('click')
+    const menu = w.find('[role="menu"]')
+    expect(menu.findAll('[role="menuitem"]')).toHaveLength(3)
+    expect(menu.text()).not.toContain('Blog')
+  })
+
+  it('keeps the Get Started call to action', async () => {
+    const w = await mount()
+    expect(w.html()).toContain('/get-started')
+    expect(w.text()).toContain('Get Started')
+  })
+
+  it('uses no em dashes anywhere in the rendered nav', async () => {
+    const w = await mount()
+    expect(w.text()).not.toContain('—')
+  })
+
+  it('leaves Pricing as the only flat desktop link', async () => {
+    const w = await mount()
+    // Scoped to the desktop nav on purpose. The mobile drawer keeps its
+    // accordion panels in the DOM via v-show, so wrapper.text() sees
+    // collapsed items and a whole-component assertion would be a lie.
+    const desktop = w.find('[data-desktop-nav]')
+    expect(desktop.findAll('a').map(a => a.text())).toEqual(['Pricing'])
+  })
+})

--- a/test/nuxt/navdropdown.spec.ts
+++ b/test/nuxt/navdropdown.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { defineComponent } from 'vue'
+import NavDropdown from '~/components/homepage/NavDropdown.vue'
+
+// Component that resets the shared useState state by calling useState
+// and setting it to null. Must be mounted before each test to ensure
+// clean state, then immediately unmounted. See test/nuxt/dropdown.spec.ts.
+const StateResetter = defineComponent({
+  setup() {
+    const openId = useState('nav:openDropdown', () => null)
+    openId.value = null
+    return {}
+  },
+  template: '<div></div>',
+})
+
+const items = [
+  { label: 'Internal', to: '/pricing' },
+  { label: 'External', to: 'https://example.com', external: true, tagline: 'A tagline' },
+]
+
+describe('NavDropdown', () => {
+  beforeEach(async () => {
+    const resetter = await mountSuspended(StateResetter)
+    await resetter.unmount()
+  })
+
+  it('renders the label and stays closed initially', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    expect(w.text()).toContain('Products')
+    expect(w.find('[role="menu"]').exists()).toBe(false)
+  })
+
+  it('sets aria attributes on the trigger', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    const trigger = w.find('button')
+    expect(trigger.attributes('aria-haspopup')).toBe('menu')
+    expect(trigger.attributes('aria-expanded')).toBe('false')
+  })
+
+  it('flips aria-expanded and shows the menu on click', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    await w.find('button').trigger('click')
+    expect(w.find('button').attributes('aria-expanded')).toBe('true')
+    expect(w.find('[role="menu"]').exists()).toBe(true)
+  })
+
+  it('renders every item with role menuitem', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    await w.find('button').trigger('click')
+    expect(w.findAll('[role="menuitem"]')).toHaveLength(2)
+  })
+
+  it('gives external links target and rel', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    await w.find('button').trigger('click')
+    const external = w.findAll('[role="menuitem"]')[1]
+    expect(external.attributes('target')).toBe('_blank')
+    expect(external.attributes('rel')).toBe('noopener noreferrer')
+  })
+
+  it('does not put target or rel on internal links', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    await w.find('button').trigger('click')
+    const internal = w.findAll('[role="menuitem"]')[0]
+    expect(internal.attributes('target')).toBeUndefined()
+  })
+
+  it('renders taglines when present', async () => {
+    const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
+    await w.find('button').trigger('click')
+    expect(w.text()).toContain('A tagline')
+  })
+})

--- a/test/nuxt/navdropdown.spec.ts
+++ b/test/nuxt/navdropdown.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { defineComponent } from 'vue'
+import { defineComponent, nextTick } from 'vue'
 import NavDropdown from '~/components/homepage/NavDropdown.vue'
 
 // Component that resets the shared useState state by calling useState
@@ -71,5 +71,133 @@ describe('NavDropdown', () => {
     const w = await mountSuspended(NavDropdown, { props: { id: 'x', label: 'Products', items } })
     await w.find('button').trigger('click')
     expect(w.text()).toContain('A tagline')
+  })
+
+  // FIX 2 regression: arrow-key roving focus is only reachable if focus
+  // actually lands inside the panel when it opens. Before this fix,
+  // focus stayed on the trigger (a sibling of the panel) and keydown
+  // never reached onPanelKeydown, so ArrowDown/Up/Home/End were dead.
+  describe('keyboard behaviour', () => {
+    const items3 = [
+      { label: 'One', to: '/pricing' },
+      { label: 'Two', to: '/about' },
+      { label: 'Three', to: 'https://example.com', external: true },
+    ]
+
+    // These tests each mount with attachTo: document.body to get real
+    // activeElement tracking, and each gets its own dropdown id. isOpen
+    // is a computed over the single shared nav:openDropdown useState, so
+    // reusing an id across two attachTo-mounted instances in the same
+    // file lets a not-yet-torn-down previous instance's watchers and
+    // document-level keydown listener react to this test's state changes
+    // too, racing with this test's own focus calls. Unique ids make each
+    // test's dropdown deaf to every other instance's state changes.
+    it('moves focus to the first menu item once the panel opens', async () => {
+      const w = await mountSuspended(NavDropdown, {
+        props: { id: 'kb-open', label: 'Products', items: items3 },
+        attachTo: document.body,
+      })
+      try {
+        await w.find('button').trigger('click')
+        await nextTick()
+        const first = w.findAll('[role="menuitem"]')[0].element
+        expect(document.activeElement).toBe(first)
+      } finally {
+        await w.unmount()
+      }
+    })
+
+    // The spec required this test but nobody wrote it: closeAndRefocus
+    // already existed in useDropdown, it was simply unverified.
+    it('Escape closes the menu and returns focus to the trigger', async () => {
+      const w = await mountSuspended(NavDropdown, {
+        props: { id: 'kb-escape', label: 'Products', items: items3 },
+        attachTo: document.body,
+      })
+      try {
+        const trigger = w.find('button').element
+        await w.find('button').trigger('click')
+        await nextTick()
+        expect(w.find('[role="menu"]').exists()).toBe(true)
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+        await nextTick()
+
+        expect(w.find('[role="menu"]').exists()).toBe(false)
+        expect(document.activeElement).toBe(trigger)
+      } finally {
+        await w.unmount()
+      }
+    })
+
+    // FIX 1 regression: Tab used to close the menu unconditionally,
+    // including while moving between two items that are both natively
+    // tabbable (real anchors, not a roving-tabindex set). That destroyed
+    // whichever item the browser had just focused, and focus fell back
+    // to <body> mid-navigation. Moving between items must be left
+    // entirely to native Tab order; the menu must stay open.
+    it('Tab between items does not close the menu', async () => {
+      const w = await mountSuspended(NavDropdown, {
+        props: { id: 'kb-tab-mid', label: 'Products', items: items3 },
+        attachTo: document.body,
+      })
+      try {
+        await w.find('button').trigger('click')
+        await nextTick()
+        const menuitems = w.findAll('[role="menuitem"]').map(i => i.element)
+        menuitems[0].focus()
+
+        const panel = w.find('[role="menu"]').element
+        panel.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }))
+
+        expect(w.find('[role="menu"]').exists()).toBe(true)
+
+        // Still open even after the deferred-close window would have
+        // fired, because this Tab press never qualified for it.
+        await new Promise(requestAnimationFrame)
+        await nextTick()
+        expect(w.find('[role="menu"]').exists()).toBe(true)
+      } finally {
+        await w.unmount()
+      }
+    })
+
+    // FIX 1 regression, the boundary case: Tab off the LAST item is
+    // correctly allowed to close the menu (that Tab is leaving the
+    // panel), but must not do so synchronously. Closing inside the
+    // keydown handler would remove the still-focused last item before
+    // the browser's own default Tab action gets a turn to move focus off
+    // it, stranding focus on <body> and restarting sequential navigation
+    // from the top of the page.
+    it('defers closing on Tab off the last item so focus is never stranded', async () => {
+      const w = await mountSuspended(NavDropdown, {
+        props: { id: 'kb-tab-last', label: 'Products', items: items3 },
+        attachTo: document.body,
+      })
+      try {
+        await w.find('button').trigger('click')
+        await nextTick()
+        const menuitems = w.findAll('[role="menuitem"]').map(i => i.element)
+        const last = menuitems[menuitems.length - 1]
+        last.focus()
+
+        const panel = w.find('[role="menu"]').element
+        panel.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }))
+
+        // Not closed yet, and `last` still holds focus: the browser has
+        // not performed its default Tab move yet, so we must not have
+        // ripped the panel out from under it.
+        expect(w.find('[role="menu"]').exists()).toBe(true)
+        expect(document.activeElement).toBe(last)
+
+        // After the browser's default focus-move would have had its
+        // turn, it is safe to close.
+        await new Promise(requestAnimationFrame)
+        await nextTick()
+        expect(w.find('[role="menu"]').exists()).toBe(false)
+      } finally {
+        await w.unmount()
+      }
+    })
   })
 })

--- a/test/nuxt/pricingcard.spec.ts
+++ b/test/nuxt/pricingcard.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import PricingCard from '~/components/homepage/PricingCard.vue'
+
+// happy-dom does no layout, so overflow itself cannot be asserted here.
+// What these tests DO guard is the mechanism that caused it: a fixed
+// oversized type scale, and a flex row that could neither wrap nor shrink.
+//
+// Every size assertion reads the class list of [data-price] specifically.
+// Matching against the whole rendered HTML is not safe: the card title
+// carries "text-2xl md:text-3xl", so a document-wide search for a size
+// class passes even when the price is sized wrong.
+const mount = (priceText: string | null) =>
+  mountSuspended(PricingCard, {
+    props: { planId: 'pro', title: 'Professional', priceText, priceSuffix: '/month' },
+  })
+
+const priceClasses = async (priceText: string) =>
+  (await mount(priceText)).find('[data-price]').classes()
+
+describe('PricingCard price sizing', () => {
+  it('keeps the large type for a short price', async () => {
+    expect(await priceClasses('Free')).toContain('md:text-5xl')
+  })
+
+  it('steps down for a long localized price so it fits the card', async () => {
+    // 11 characters. text-5xl overflows a card column of roughly 314px.
+    const classes = await priceClasses('\u20A6450,000.00')
+    expect(classes).toContain('md:text-4xl')
+    expect(classes).not.toContain('md:text-5xl')
+  })
+
+  it('steps down again for an even longer price', async () => {
+    const classes = await priceClasses('\u20A61,500,000.00')
+    expect(classes).toContain('md:text-3xl')
+    expect(classes).not.toContain('md:text-4xl')
+    expect(classes).not.toContain('md:text-5xl')
+  })
+
+  it('lets the price row wrap and shrink instead of overflowing', async () => {
+    const w = await mount('\u20A6450,000.00')
+    const row = w.find('[data-price]').element.parentElement as HTMLElement
+    expect(row.className).toContain('flex-wrap')
+    expect(w.find('[data-price]').classes()).toContain('min-w-0')
+  })
+
+  it('still renders the suffix alongside a long price', async () => {
+    const w = await mount('\u20A6450,000.00')
+    expect(w.text()).toContain('/month')
+  })
+
+  it('shows the skeleton and no suffix while the price is loading', async () => {
+    const w = await mount(null)
+    expect(w.html()).toContain('animate-pulse')
+    expect(w.text()).not.toContain('/month')
+  })
+})

--- a/test/nuxt/productsuite.spec.ts
+++ b/test/nuxt/productsuite.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import ProductSuite from '~/components/homepage/ProductSuite.vue'
+
+describe('ProductSuite', () => {
+  it('no longer calls the section Product Suite', async () => {
+    const w = await mountSuspended(ProductSuite)
+    expect(w.find('h2').text()).toBe('What XeliAI does')
+  })
+
+  it('has no dead filter buttons', async () => {
+    const w = await mountSuspended(ProductSuite)
+    const labels = w.findAll('button').map(b => b.text())
+    expect(labels).not.toContain('All')
+    expect(labels).not.toContain('Support')
+    expect(labels).not.toContain('Automation')
+  })
+})


### PR DESCRIPTION
Adds an OpenAI-style multi-product navigation shell to the marketing site, and fixes two visible bugs found along the way.

## What this adds

- **Products menu** listing XeliAI, XeliAI Trivia, XeliAI Labs and XeliAI Blog
- **Business** and **Company** menus
- **Log in dropdown** routing to each product's own login. There is no SSO: the three apps have unrelated auth systems (Sanctum/Mongo, JWT/Postgres, none), so these are plain links and the menu never implies knowledge of a Trivia or Labs session
- **Footer** rebuilt from the same registry, with **Powered by LiteSigma Tech** linking to https://www.litesigma.com.ng/
- **Ecosystem strip** on the landing page for visitors who scroll rather than open menus

One registry, `app/utils/ecosystem.js`, feeds the desktop nav, the mobile drawer, the login menu, the footer and the strip, so the product list cannot drift between them.

## Bugs fixed

- **Footer linked to `/features`, which has no page.** Vue Router was logging `No match found for location with path "/features"` on every render.
- **A "Help Center" link pointed at `/contact`**, promising a page that does not exist.
- **Pricing cards overflowed.** The price is a preformatted API string, but the type was pinned at `text-4xl md:text-5xl` in a flex row that could not wrap or shrink, so `NGN 450,000.00 /month` did not fit a ~314px card column. The featured card bled outside (it needs `overflow-visible` for its ribbon), the others clipped.
- **Keyboard trap in the mobile drawer.** The drawer is hidden by CSS transform, so its contents stayed tabbable while closed; the new focus trap then locked focus inside the invisible drawer. Fixed with a `navOpen` guard plus `inert`.
- **Tab stranded focus in every dropdown.** Closing on any Tab removed the focused element mid-navigation, dropping focus to `<body>` so tabbing restarted from the top of the page.
- Removed a dead chevron affordance and the now-unused `navLinks`.

## Verification

- 64 tests across 10 files (this repo had none before)
- `npx nuxt build` green
- Reviewed per task, plus a whole-branch review

## Before merging, please note

- **Not visually verified in a browser.** Everything is tests and code review. happy-dom does no layout, so no test here can prove text fits inside a box. Worth a look at the nav, footer and pricing page on desktop and phone.
- **Set three Amplify env vars per branch:** `NUXT_PUBLIC_TRIVIA_URL`, `NUXT_PUBLIC_LABS_URL`, `NUXT_PUBLIC_BLOG_URL`. The build is static (`.output/public`, no Nitro), so `runtimeConfig.public` is baked in at build time and cannot be overridden at runtime. Defaults point at production, so an unset staging branch silently links visitors into production. Documented in the new `.env.example`.
- **Product taglines are placeholder marketing copy** and want an owner review.
- **`Log in -> Labs` points at the Labs home page**, not a login form, because Labs has no working auth yet.

Design and plan are committed under `docs/superpowers/`.
